### PR TITLE
Updating the tinytutorial to work with Docker

### DIFF
--- a/qanary_component-NED-DBpedia-Spotlight/src/main/resources/config/application.properties
+++ b/qanary_component-NED-DBpedia-Spotlight/src/main/resources/config/application.properties
@@ -6,7 +6,8 @@ spring.application.description=${app.name} is a Qanary component
 # the URL of the Qanary pipeline server
 spring.boot.admin.client.url=http://localhost:8080
 # the service url 
-spring.boot.admin.client.service-base-url=http://localhost:10008
+#spring.boot.admin.client.service-base-url=http://localhost:10008
+spring.boot.admin.client.instance.service-base-url=http://localhost:10008
 #spring.security.user.name=admin
 #spring.security.user.password=admin
 #management.endpoints.web.exposure.include=*

--- a/qanary_component-QB-SimpleRealNameOfSuperHero/Dockerfile
+++ b/qanary_component-QB-SimpleRealNameOfSuperHero/Dockerfile
@@ -1,7 +1,7 @@
-FROM openjdk:8-jre                                                                                                                                                                                                                              
-
-ENTRYPOINT ["/usr/local/openjdk-8/bin/java", "-jar", "/usr/share/qanary-components/qanary-service.jar"]
+FROM openjdk:11                                                                                                                                                                                                                             
 
 # Add the service itself
 ARG JAR_FILE
-ADD target/${JAR_FILE} /usr/share/qanary-components/qanary-service.jar
+ADD target/${JAR_FILE} /qanary-service.jar
+
+ENTRYPOINT ["java", "-jar", "/qanary-service.jar"]

--- a/qanary_component-QB-SimpleRealNameOfSuperHero/Dockerfile
+++ b/qanary_component-QB-SimpleRealNameOfSuperHero/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11                                                                                                                                                                                                                              
+FROM openjdk:8-jre                                                                                                                                                                                                                              
 
 ENTRYPOINT ["/usr/local/openjdk-8/bin/java", "-jar", "/usr/share/qanary-components/qanary-service.jar"]
 

--- a/qanary_component-QB-SimpleRealNameOfSuperHero/src/main/resources/config/application.properties
+++ b/qanary_component-QB-SimpleRealNameOfSuperHero/src/main/resources/config/application.properties
@@ -6,6 +6,7 @@ spring.application.description=${app.name} is a Qanary component
 # the URL of the Qanary pipeline server
 spring.boot.admin.client.url=http://localhost:8080
 # the service url 
+#spring.boot.admin.client.service-base-url=http://localhost:10013
 spring.boot.admin.client.instance.service-base-url=http://localhost:10013
 #spring.security.user.name=admin
 #spring.security.user.password=admin


### PR DESCRIPTION
 Fixing problems with the Docker of the `tinytutorial`:

- The application.properties now runs at localhost
- Dockerfile is performed right with java 8