### PR TITLE
TinyTutorial build failure

### DIFF
--- a/qanary_component-QB-SimpleRealNameOfSuperHero/src/main/resources/config/application.properties
+++ b/qanary_component-QB-SimpleRealNameOfSuperHero/src/main/resources/config/application.properties
@@ -1,10 +1,12 @@
 # Update the port number
 server.port=10013
 spring.application.name=QueryBuilderSimpleRealNameOfSuperHero
-spring.application.description=${app.name} is a Qanary component
+spring.application.description=${spring.application.name} is a Qanary component
 
 # the URL of the Qanary pipeline server
-spring.boot.admin.client.url=http://localhost:8080
+spring.boot.admin.url=http://localhost:8080
+spring.boot.admin.client.url=${spring.boot.admin.url}
+
 # the service url 
 #spring.boot.admin.client.service-base-url=http://localhost:10013
 spring.boot.admin.client.instance.service-base-url=http://localhost:10013


### PR DESCRIPTION
The tinytutorial build doesn't work as expected:

` mvn clean package -Ddockerfile.skip=true -P tinytutorial `

This leads to the following exception because QanaryComponentConfiguration expects
"spring.boot.admin.url" and "spring.boot.admin.client.url".

`org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'qanaryComponentConfiguration': Invocation of init method failed; nested exception is org.apache.commons.cli.MissingArgumentException: spring.boot.admin.url`

Qanary uses  Spring Boot in the versions 1.3.3 and 2.1.6. Since Spring Boot >= 2.0.0 configuration changed from spring.boot.admin.url to spring.boot.admin.client.url. 

Additional change:
${app.name} in application.properties changed to correct variable ${spring.application.name}