### PR TITLE
Change main class location in pom

### DIFF
--- a/qanary_component-LD-Shuyo/pom.xml
+++ b/qanary_component-LD-Shuyo/pom.xml
@@ -81,7 +81,7 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>
-					<mainClass>eu.wdaqua.qanary.ambiverse.Application</mainClass>
+					<mainClass>eu.wdaqua.qanary.languagedetection.Application</mainClass>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
Class Application is located in `eu.wdaqua.qanary.languagedetection.Application`, not `eu.wdaqua.qanary.ambiverse.Application`.