### PR TITLE
fix (sparql): correct oa:annotatedBy values

### DIFF
--- a/qanary_component-QB-ComicCharacterAlterEgoSimpleDBpediaQueryBuilder/pom.xml
+++ b/qanary_component-QB-ComicCharacterAlterEgoSimpleDBpediaQueryBuilder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.wdaqua.qanary.component</groupId>
     <artifactId>qanary_component-QB-ComicCharacterAlterEgoSimpleDBpediaQueryBuilder</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>

--- a/qanary_component-QB-ComicCharacterAlterEgoSimpleDBpediaQueryBuilder/src/main/java/eu/wdaqua/qanary/component/querybuilder/ComicCharacterAlterEgoSimpleDBpediaQueryBuilder.java
+++ b/qanary_component-QB-ComicCharacterAlterEgoSimpleDBpediaQueryBuilder/src/main/java/eu/wdaqua/qanary/component/querybuilder/ComicCharacterAlterEgoSimpleDBpediaQueryBuilder.java
@@ -45,7 +45,7 @@ public class ComicCharacterAlterEgoSimpleDBpediaQueryBuilder extends QanaryCompo
 		logger.info("process: {}", myQanaryMessage);
 
 		//read question from database
-		QanaryQuestion<String> qanaryQuestion = new QanaryQuestion<String>(myQanaryMessage);
+		QanaryQuestion<String> qanaryQuestion = new QanaryQuestion<>(myQanaryMessage);
 		String question = qanaryQuestion.getTextualRepresentation();
 		QanaryUtils qanaryUtils = this.getUtils(myQanaryMessage);
 
@@ -75,8 +75,10 @@ public class ComicCharacterAlterEgoSimpleDBpediaQueryBuilder extends QanaryCompo
 				+ "                                     oa:end   ?endOfSpecificResource " //
 				+ "                                    ]" //
 				+ "                  ] ." //
-				+ "    ?a oa:annotatedBy <urn:qanary:"+this.applicationName+"> . " //
 				+ "    ?a oa:annotatedAt ?time ." //
+// 					   The component was originally built to look specifically for
+// 					   annotations of ComicCharacterNameSimpleNamedEntityRecognizer:
+//				+ "    ?a oa:annotatedBy <urn:qanary:component:ComicCharacterNameSimpleNamedEntityRecognizer> ." //
 				+ "}";
 
 
@@ -121,7 +123,7 @@ public class ComicCharacterAlterEgoSimpleDBpediaQueryBuilder extends QanaryCompo
 					+ dbpediaQuery.replace("\"", "\\\"").replace("\n", "\\n") + "\"^^xsd:string ." //
 					+ "        ?newAnnotation qa:score \"1.0\"^^xsd:float ."
 					+ "        ?newAnnotation oa:annotatedAt ?time ." //
-					+ "        ?newAnnotation oa:annotatedBy <urn:service> ." //
+					+ "        ?newAnnotation oa:annotatedBy <urn:qanary:component:"+this.applicationName+"> ." //
 					+ "    }" //
 					+ "}" //
 					+ "WHERE {" //

--- a/qanary_component-QB-ComicCharacterAlterEgoSimpleDBpediaQueryBuilder/src/main/java/eu/wdaqua/qanary/component/querybuilder/ComicCharacterAlterEgoSimpleDBpediaQueryBuilder.java
+++ b/qanary_component-QB-ComicCharacterAlterEgoSimpleDBpediaQueryBuilder/src/main/java/eu/wdaqua/qanary/component/querybuilder/ComicCharacterAlterEgoSimpleDBpediaQueryBuilder.java
@@ -118,7 +118,10 @@ public class ComicCharacterAlterEgoSimpleDBpediaQueryBuilder extends QanaryCompo
 					+ "INSERT { " //
 					+ "GRAPH <" + myQanaryMessage.getInGraph().toString() + ">  {" //
 					+ "        ?newAnnotation rdf:type qa:AnnotationOfAnswerSPARQL ." //
-					+ "        ?newAnnotation oa:hasTarget <urn:question:1> ." //
+					+ "        ?newAnnotation oa:hasTarget [ " //
+					+ "                 a    oa:SpecificResource; " //
+					+ "                 oa:hasSource    <" + qanaryQuestion.getUri() + ">; " //
+					+ "        ] . " //
 					+ "        ?newAnnotation oa:hasBody \""
 					+ dbpediaQuery.replace("\"", "\\\"").replace("\n", "\\n") + "\"^^xsd:string ." //
 					+ "        ?newAnnotation qa:score \"1.0\"^^xsd:float ."


### PR DESCRIPTION
The SPARQL query to get annotations of found entities contained the component's own name for oa:annotatedBy, causing the query to find no relevant results. The triple pattern is now removed.

The SPARQL query to insert the computed result was missing the component's name for oa:annotatedBy. The pattern now uses spring.application.name, specified in application.properties.