### PR TITLE
Parameter refactoring for Python EAT component

### DIFF
--- a/qanary_component-Python-QC-EAT-classifier/Dockerfile
+++ b/qanary_component-Python-QC-EAT-classifier/Dockerfile
@@ -2,12 +2,14 @@ FROM python:3.6.6-slim
 
 COPY requirements.txt ./
 
-RUN pip install --upgrade pip -r requirements.txt; exit 0
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt; exit 0
+RUN pip install gunicorn
 
 COPY app app
-COPY app.conf run.py  ./
+COPY app.conf run.py boot.sh  ./
 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-EXPOSE 5000
-ENTRYPOINT ["python", "run.py"]
+RUN chmod +x boot.sh
+ENTRYPOINT ["./boot.sh"]

--- a/qanary_component-Python-QC-EAT-classifier/app.conf
+++ b/qanary_component-Python-QC-EAT-classifier/app.conf
@@ -1,13 +1,9 @@
 [ServiceConfiguration]
-# the URL of the Spring Boot Admin server endpoint (e.g., http://localhost:8080)
-springbootadminserverurl = http://localhost:8080/
 # Spring Boot Admin server credentials (by default: admin, admin)
 springbootadminserveruser = admin
 springbootadminserverpassword = admin
 # the name of your service (e.g., my service)
 servicename = answer_type_classifier
-# the port (integer) of your service (e.g., 5000)
-serviceport = 5000
 # the host of your service (e.g., http://127.0.0.1)
 servicehost = http://127.0.0.1
 # a description of your service functionality 
@@ -16,3 +12,6 @@ servicedescription = DBpedia Ontology answer type classification component. The 
 serviceversion = 0.1.0
 # classification endpoint
 classificationendpoint = http://webengineering.ins.hs-anhalt.de:41066/answer_type_classifier/predict
+# deprecated
+springbootadminserverurl = deprecated
+serviceport = deprecated

--- a/qanary_component-Python-QC-EAT-classifier/boot.sh
+++ b/qanary_component-Python-QC-EAT-classifier/boot.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo The port number is: $SERVER_PORT
+echo The Qanary pipeline URL is: $SPRING_BOOT_ADMIN_URL
+if [ -n $PORT ]
+then
+    exec gunicorn -b :$SERVER_PORT --access-logfile - --error-logfile - run:app
+fi

--- a/qanary_component-Python-QC-EAT-classifier/boot.sh
+++ b/qanary_component-Python-QC-EAT-classifier/boot.sh
@@ -2,7 +2,7 @@
 
 echo The port number is: $SERVER_PORT
 echo The Qanary pipeline URL is: $SPRING_BOOT_ADMIN_URL
-if [ -n $PORT ]
+if [ -n $SERVER_PORT ]
 then
     exec gunicorn -b :$SERVER_PORT --access-logfile - --error-logfile - run:app
 fi

--- a/qanary_component-Python-QC-EAT-classifier/run.py
+++ b/qanary_component-Python-QC-EAT-classifier/run.py
@@ -1,3 +1,4 @@
+import os
 import logging
 import argparse
 from flask import Flask, render_template
@@ -9,56 +10,54 @@ from qanary_helpers.registration import Registration
 from qanary_helpers.registrator import Registrator
 
 
+logging.basicConfig(format='%(asctime)s - %(message)s', level=logging.INFO)
+
+configfile = "app.conf"
+
+configuration = Configuration(configfile, [
+    'springbootadminserveruser',
+    'springbootadminserverpassword',
+    'servicehost',
+    'servicename',
+    'servicedescription',
+    'serviceversion'
+])
+
+# read environment variables
+configuration.springbootadminserverurl = os.environ['SPRING_BOOT_ADMIN_URL']
+configuration.serviceport = os.environ['SERVER_PORT']
+
+try:
+    configuration.serviceport = int(configuration.serviceport)  # ensure an int value for the server port
+except Exception as e:
+    logging.error(
+        "in configfile '%s': serviceport '%s' is not valid (%s)" % (configfile, configuration.serviceport, e))
+
+# define metadata that will be shown in the Spring Boot Admin server UI
+metadata = {
+    "start": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+    "description": configuration.servicedescription,
+    "about": "%s:%d%s" % (configuration.servicehost, configuration.serviceport, aboutendpoint),
+    "written in": "Python"
+}
+
+# initialize the registation object, to be send to the Spring Boot Admin server
+myRegistration = Registration(
+    name=configuration.servicename,
+    serviceUrl="%s:%d" % (configuration.servicehost, configuration.serviceport),
+    healthUrl="%s:%d%s" % (configuration.servicehost, configuration.serviceport, healthendpoint),
+    metadata=metadata
+)
+
+# start a thread that will contact iteratively the Spring Boot Admin server
+registratorThread = Registrator(
+    configuration.springbootadminserverurl,
+    configuration.springbootadminserveruser,
+    configuration.springbootadminserverpassword,
+    myRegistration
+)
+registratorThread.start()
+
 if __name__ == "__main__":
-    logging.basicConfig(format='%(asctime)s - %(message)s', level=logging.INFO)
-
-    # allow configuration of the configfile via command line parameters
-    argparser = argparse.ArgumentParser(
-        description='You might provide a configuration file, otherwise "%s" is used.' % (configfile))
-    argparser.add_argument('-c', '--configfile', action='store', dest='configfile', default=configfile,
-                           help='overwrite the default configfile "%s"' % (configfile))
-    configfile = argparser.parse_args().configfile
-    configuration = Configuration(configfile, [
-        'springbootadminserverurl',
-        'springbootadminserveruser',
-        'springbootadminserverpassword',
-        'servicehost',
-        'serviceport',
-        'servicename',
-        'servicedescription',
-        'serviceversion'
-    ])
-
-    try:
-        configuration.serviceport = int(configuration.serviceport)  # ensure an int value for the server port
-    except Exception as e:
-        logging.error(
-            "in configfile '%s': serviceport '%s' is not valid (%s)" % (configfile, configuration.serviceport, e))
-
-    # define metadata that will be shown in the Spring Boot Admin server UI
-    metadata = {
-        "start": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-        "description": configuration.servicedescription,
-        "about": "%s:%d%s" % (configuration.servicehost, configuration.serviceport, aboutendpoint),
-        "written in": "Python"
-    }
-
-    # initialize the registation object, to be send to the Spring Boot Admin server
-    myRegistration = Registration(
-        name=configuration.servicename,
-        serviceUrl="%s:%d" % (configuration.servicehost, configuration.serviceport),
-        healthUrl="%s:%d%s" % (configuration.servicehost, configuration.serviceport, healthendpoint),
-        metadata=metadata
-    )
-
-    # start a thread that will contact iteratively the Spring Boot Admin server
-    registratorThread = Registrator(
-        configuration.springbootadminserverurl,
-        configuration.springbootadminserveruser,
-        configuration.springbootadminserverpassword,
-        myRegistration
-    )
-    registratorThread.start()
-
     # start the web service
     app.run(debug=True, port=configuration.serviceport)


### PR DESCRIPTION
An agreement with @p-Heinze was made to switch `serverport` and `springbootadminurl` to environment variables in order to unify the deployment process from `docker-compose`. In this PR:
* `serverport` and `springbootadminurl` are marked as deprecated in `app.conf`;
* `serverport` and `springbootadminurl` are read from env variables now;
* execution with `gunicorn` server was added and `Dockerfile` was changed according to this.

This PR needs to be validated by:
- [x] @p-Heinze 
- [x] @anbo-de 