### PR TITLE
Use most current Dockerfile version for Comic Character Real Name DBpedia Query Builder component

### DIFF
--- a/qanary_component-QB-ComicCharacterAlterEgoSimpleDBpediaQueryBuilder/Dockerfile
+++ b/qanary_component-QB-ComicCharacterAlterEgoSimpleDBpediaQueryBuilder/Dockerfile
@@ -1,14 +1,7 @@
 FROM openjdk:11
 
-# to prevent complications it is suggest to publish exactly the exposed port via 
-#    docker run -p ...:...
-EXPOSE 5555
-
-# you need to pass the address of the Qanary Pipeline component (e.g., the "real" IP address, not localhost) via 
-#    docker run --env qanary.pipeline.url=... 
-# to the Qanary component inside the Docker container (which will perform a call back on the provided URL)
-ENTRYPOINT ["java", "-jar", "-Dspring.boot.admin.url=${qanary.pipeline.url}", "/usr/share/qanary-components/qanary-service.jar"]
-
 # Add the service itself
 ARG JAR_FILE
-ADD target/${JAR_FILE} /usr/share/qanary-components/qanary-service.jar
+ADD target/${JAR_FILE} /qanary-service.jar
+
+ENTRYPOINT ["java", "-jar", "/qanary-service.jar"]


### PR DESCRIPTION
The Dockerfile of QB ComicCharacterAlterEgoSimpleDBpediaQueryBuilder was
referencing parameter `qanary.pipeline.url` which is no longer present
in the component's configuration.