### PR TITLE
fixed <mainClass> in pom.xml Component - qa.qanary_component-DiambiguationProperty-OKBQA

### DIFF
--- a/qa.qanary_component-DiambiguationProperty-OKBQA/pom.xml
+++ b/qa.qanary_component-DiambiguationProperty-OKBQA/pom.xml
@@ -73,7 +73,7 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
-                    <mainClass>eu.wdaqua.qanary.annotationofspotproperty.Application</mainClass>
+                    <mainClass>eu.wdaqua.qanary.diambiguationproperty.Application</mainClass>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
When I try to start qa.qanary_component-DiambiguationProperty-OKBQA using 
`java -jar qa.qanary_component-DiambiguationProperty-OKBQA/target/qa.qanary_component-DiambiguationProperty-OKBQA-X.Y.Z.jar` command I was getting following error   
![fix](https://user-images.githubusercontent.com/36166862/119883403-22132880-bf4d-11eb-91bc-04c17a9d24a8.PNG)
I fixed it by changing <mainClass> in pom.xml
