### PR TITLE
Log4j fix

### DIFF
--- a/qa.qanary_component-AnnotationofSpotClass-tgm/pom.xml
+++ b/qa.qanary_component-AnnotationofSpotClass-tgm/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.wdaqua.qanary.component</groupId>
     <artifactId>qa_qanary_component-AnnotationofSpotClass-tgm</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
@@ -13,7 +13,7 @@
     </parent>
     <properties>
         <java.version>11</java.version>
-        <qanary.version>[2.0.0,3.0.0)</qanary.version>
+        <qanary.version>[2.1.1,3.0.0)</qanary.version>
         <docker.image.prefix>qanary</docker.image.prefix>
         <docker.image.name>annotation-of-spot-class</docker.image.name>
         <dockerfile-maven-version>1.4.13</dockerfile-maven-version>
@@ -65,6 +65,18 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path-assert</artifactId>
             <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>[2.15.0,3.)</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>

--- a/qa.qanary_component-AnnotationofSpotProperty-tgm/pom.xml
+++ b/qa.qanary_component-AnnotationofSpotProperty-tgm/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.wdaqua.qanary.component</groupId>
     <artifactId>qa.qanary_component-AnnotationofSpotProperty-tgm</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
@@ -13,7 +13,7 @@
     </parent>
     <properties>
         <java.version>11</java.version>
-        <qanary.version>[2.0.0,3.0.0)</qanary.version>
+        <qanary.version>[2.1.1,3.0.0)</qanary.version>
         <docker.image.prefix>qanary</docker.image.prefix>
         <docker.image.name>annotation-of-spot-property</docker.image.name>
         <dockerfile-maven-version>1.4.13</dockerfile-maven-version>
@@ -65,6 +65,18 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path-assert</artifactId>
             <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>[2.15.0,3.)</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>

--- a/qa.qanary_component-AnnotationofSpotProperty-tgm/src/main/java/eu/wdaqua/qanary/annotationofspotproperty/AnnotationofSpotProperty.java
+++ b/qa.qanary_component-AnnotationofSpotProperty-tgm/src/main/java/eu/wdaqua/qanary/annotationofspotproperty/AnnotationofSpotProperty.java
@@ -42,7 +42,7 @@ public class AnnotationofSpotProperty extends QanaryComponent {
 
 	private final String applicationName;
 
-	public AnnotationofSpotProperty(@Value("${spring.applcation.name}") final String applicationName) {
+	public AnnotationofSpotProperty(@Value("${spring.application.name}") final String applicationName) {
 		this.applicationName = applicationName;
 	}
 
@@ -50,44 +50,41 @@ public class AnnotationofSpotProperty extends QanaryComponent {
 	/**
      * runCurlPOSTWithParam is a function to fetch the response from a CURL command using POST.
      */
-    public static String runCurlPOSTWithParam(String weburl,String data,String contentType) throws Exception
+    public static String runCurlPOSTWithParam(String weburl, String data, String contentType) throws Exception
 	{
 		
     	
     	//The String xmlResp is to store the output of the Template generator web service accessed via CURL command
     	
         String xmlResp = "";
-        try {
-        	URL url = new URL(weburl);
-    		HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-    		
-    		connection.setRequestMethod("POST");
-    		connection.setDoOutput(true);
-    		
-    		connection.setRequestProperty("Content-Type", contentType);
-    				
-    		DataOutputStream wr = new DataOutputStream(connection.getOutputStream());
-    		wr.writeBytes(data);
-    		wr.flush();
-    		wr.close();
-    		
-    		
-    	
-    		BufferedReader in = new BufferedReader(
-    		        new InputStreamReader(connection.getInputStream()));
-    		String inputLine;
-    		StringBuffer response = new StringBuffer();
 
-    		while ((inputLine = in.readLine()) != null) {
-    			response.append(inputLine);
-    		}
-    		in.close();
-    		xmlResp = response.toString();
-    		
-    		System.out.println("Curl Response: \n"+xmlResp);
-            logger.info("Response {}", xmlResp);
-        } catch (Exception e) {
-        }
+    	URL url = new URL(weburl);
+		HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+		
+		connection.setRequestMethod("POST");
+		connection.setDoOutput(true);
+		
+		connection.setRequestProperty("Content-Type", contentType);
+				
+		DataOutputStream wr = new DataOutputStream(connection.getOutputStream());
+		wr.writeBytes(data);
+		wr.flush();
+		wr.close();
+	
+		BufferedReader in = new BufferedReader(
+		        new InputStreamReader(connection.getInputStream()));
+		String inputLine;
+		StringBuffer response = new StringBuffer();
+
+		while ((inputLine = in.readLine()) != null) {
+			response.append(inputLine);
+		}
+		in.close();
+		xmlResp = response.toString();
+		
+		logger.info("Curl Response: {}", xmlResp);
+        logger.info("Response {}", xmlResp);
+
         return (xmlResp);
 
 	}
@@ -103,11 +100,8 @@ public class AnnotationofSpotProperty extends QanaryComponent {
 		HashSet<String> dbLinkListSet = new HashSet<String>();
 		logger.info("process: {}", myQanaryMessage);
 		QanaryUtils myQanaryUtils = this.getUtils(myQanaryMessage);
-		QanaryQuestion<String> myQanaryQuestion = new QanaryQuestion(myQanaryMessage);
+		QanaryQuestion<String> myQanaryQuestion = this.getQanaryQuestion(myQanaryMessage);
 		String myQuestion = myQanaryQuestion.getTextualRepresentation();
-		ArrayList<Selection> selections = new ArrayList<Selection>();
-	    //String question = URLEncoder.encode(myQuestion, "UTF-8");
-		//String question = "Which comic characters are painted by Bill Finger?";
         String language1 = "en";
         logger.info("Langauge of the Question: {}",language1);
         
@@ -120,16 +114,13 @@ public class AnnotationofSpotProperty extends QanaryComponent {
 		url = "http://ws.okbqa.org:1515/templategeneration/rocknrole";
 		//url  = "http://121.254.173.90:1515/templategeneration/rocknrole";
 		data = "{  \"string\":\""+myQuestion+"\",\"language\":\""+language1+"\"}";
-		System.out.println("\ndata :" +data);
-		System.out.println("\nComponent : 21");
+		logger.debug("data: {}", data);
+		logger.debug("Component: 21");
 		String output1="";
-		// pass the input in CURL command and call the function.
 		
-		try
-		{
+		// pass the input in CURL command and call the function.
 		output1= AnnotationofSpotProperty.runCurlPOSTWithParam(url, data, contentType);
-		}catch(Exception e){}
-//		System.out.println("The output template is:" +output1);
+
 		logger.info("The output template is: {}",output1);
 
 		PropertyRetrival propertyRetrival =  new PropertyRetrival();
@@ -151,10 +142,10 @@ public class AnnotationofSpotProperty extends QanaryComponent {
 				logger.info("Apply vocabulary alignment on outgraph");
 	          
 				String dbpediaProperty = null;
-				try {
+
 				String myKey1 = wrd.trim();
 				if(myKey1!=null && !myKey1.equals("")) {
-				System.out.println("searchDbLinkInTTL: "+myKey1);
+					logger.debug("searchDbLinkInTTL: {}", myKey1);
 					for (Entry<String, String> e : DbpediaRecorodProperty.get().tailMap(myKey1).entrySet()) {
 						    if(e.getKey().contains(myKey1)) 
 						    {
@@ -162,39 +153,36 @@ public class AnnotationofSpotProperty extends QanaryComponent {
 						      	break;
 						    }
 							ArrayList<String> strArrayList = new ArrayList<String>(Arrays.asList(e.getKey().split("\\s+")));
-							//System.out.println(strArrayList.toString());
+
 							for (String s : strArrayList)
 							{
 							    if(myKey1.compareTo(s) == 0) {
 							    	dbpediaProperty = e.getValue();
-							 }
+							    }
 							}
 							 
-							 if(dbpediaProperty!=null)
-							 break;
-							    
-							 }
+							if(dbpediaProperty!=null) {
+								break;
+							}
+					}
 		         
 				}
-				} catch (Exception e) {
-					// logger.info("Except: {}", e);
-					// TODO Auto-generated catch block
-				}
-				if(dbpediaProperty!=null)
-				dbLinkListSet.add(dbpediaProperty);
-				System.out.println("searchDbLinkInTTL: "+ dbpediaProperty);
-			}
-		System.out.println("DbLinkListSet : " +dbLinkListSet.toString());
-		logger.info("store data in graph {}", myQanaryMessage.getValues().get(myQanaryMessage.getEndpoint()));
-		// TODO: insert data in QanaryMessage.outgraph
 
+				if(dbpediaProperty!=null) {
+					dbLinkListSet.add(dbpediaProperty);
+				}
+				logger.debug("searchDbLinkInTTL: {}", dbpediaProperty);
+			}
+		logger.debug("DbLinkListSet: {}", dbLinkListSet.toString());
+		logger.info("store data in graph {}", myQanaryMessage.getValues().get(myQanaryMessage.getEndpoint()));
+
+		// insert data in QanaryMessage.outgraph		
 		logger.info("apply vocabulary alignment on outgraph");
-		// TODO: implement this (custom for every component)
 		for (String urls : dbLinkListSet) {
 			 String sparql = "prefix qa: <http://www.wdaqua.eu/qa#> " //
-	                 + "prefix oa: <http://www.w3.org/ns/openannotation/core/> " //
-	                 + "prefix xsd: <http://www.w3.org/2001/XMLSchema#> " //
-	                 + "prefix dbp: <http://dbpedia.org/property/> " //
+	                 + "PREFIX oa: <http://www.w3.org/ns/openannotation/core/> " //
+	                 + "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> " //
+	                 + "PREFIX dbp: <http://dbpedia.org/property/> " //
 	                 + "INSERT { " //
 	                 + "GRAPH <" +  myQanaryQuestion.getOutGraph()  + "> { " //
 	                 + "  ?a a qa:AnnotationOfClass . " //
@@ -210,7 +198,7 @@ public class AnnotationofSpotProperty extends QanaryComponent {
 	                 + "BIND (IRI(str(RAND())) AS ?a) ." //
 	                 + "BIND (now() as ?time) " //
 	                 + "}"; //
-	         logger.info("Sparql query {}", sparql);
+	         logger.info("SPARQL query: {}", sparql);
 	         myQanaryUtils.updateTripleStore(sparql, myQanaryMessage.getEndpoint().toString()); 
 	    }
 		return myQanaryMessage;

--- a/qa.qanary_component-DiambiguationClass-OKBQA/pom.xml
+++ b/qa.qanary_component-DiambiguationClass-OKBQA/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.wdaqua.qanary.component</groupId>
     <artifactId>qa.qanary_component-DiambiguationClass-OKBQA</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
@@ -13,7 +13,7 @@
     </parent>
     <properties>
         <java.version>11</java.version>
-        <qanary.version>[2.0.0,3.0.0)</qanary.version>
+        <qanary.version>[2.1.1,3.0.0)</qanary.version>
         <docker.image.prefix>qanary</docker.image.prefix>
         <docker.image.name>diambiguation-class-okbqa</docker.image.name>
         <dockerfile-maven-version>1.4.13</dockerfile-maven-version>
@@ -65,6 +65,18 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path-assert</artifactId>
             <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>[2.15.0,3.)</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>

--- a/qa.qanary_component-DiambiguationClass-OKBQA/src/main/java/eu/wdaqua/qanary/diambiguationclass/DiambiguationClass.java
+++ b/qa.qanary_component-DiambiguationClass-OKBQA/src/main/java/eu/wdaqua/qanary/diambiguationclass/DiambiguationClass.java
@@ -134,7 +134,7 @@ public class DiambiguationClass extends QanaryComponent {
 	 */
 	@Override
 	public QanaryMessage process(QanaryMessage myQanaryMessage) {
-		org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.OFF);
+		//org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.OFF);
 		logger.info("process: {}", myQanaryMessage);
 		// TODO: implement processing of question
 

--- a/qa.qanary_component-DiambiguationClass-OKBQA/src/main/java/eu/wdaqua/qanary/diambiguationclass/DiambiguationClass.java
+++ b/qa.qanary_component-DiambiguationClass-OKBQA/src/main/java/eu/wdaqua/qanary/diambiguationclass/DiambiguationClass.java
@@ -43,6 +43,9 @@ import eu.wdaqua.qanary.component.QanaryComponent;
  *      "https://github.com/WDAqua/Qanary/wiki/How-do-I-integrate-a-new-component-in-Qanary%3F"
  *      target="_top">Github wiki howto</a>
  */
+// TODO: replace System.out.println by logger.debug
+// TODO: remove try catch blocks with empty catch blocks
+// TODO: move Agdistis URL to configuration file 
 public class DiambiguationClass extends QanaryComponent {
 	private static final Logger logger = LoggerFactory.getLogger(DiambiguationClass.class);
 

--- a/qa.qanary_component-DiambiguationProperty-OKBQA/pom.xml
+++ b/qa.qanary_component-DiambiguationProperty-OKBQA/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.wdaqua.qanary.component</groupId>
     <artifactId>qa.qanary_component-DiambiguationProperty-OKBQA</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
@@ -13,7 +13,7 @@
     </parent>
     <properties>
         <java.version>11</java.version>
-        <qanary.version>[2.0.0,3.0.0)</qanary.version>
+        <qanary.version>[2.1.1,3.0.0)</qanary.version>
         <docker.image.prefix>qanary</docker.image.prefix>
         <docker.image.name>diambiguation-property-okbqa</docker.image.name>
         <dockerfile-maven-version>1.4.13</dockerfile-maven-version>
@@ -65,6 +65,18 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path-assert</artifactId>
             <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>[2.15.0,3.)</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>

--- a/qa.qanary_component-DiambiguationProperty-OKBQA/src/main/java/eu/wdaqua/qanary/diambiguationproperty/DiambiguationProperty.java
+++ b/qa.qanary_component-DiambiguationProperty-OKBQA/src/main/java/eu/wdaqua/qanary/diambiguationproperty/DiambiguationProperty.java
@@ -130,7 +130,7 @@ public class DiambiguationProperty extends QanaryComponent {
 	@Override
 	public QanaryMessage process(QanaryMessage myQanaryMessage) throws SparqlQueryFailed {
 		long startTime = System.currentTimeMillis();
-		org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.OFF);
+		//org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.OFF);
 		logger.info("process: {}", myQanaryMessage);
 		// TODO: implement processing of question
 

--- a/qa.qanary_component-QueryBuilder/pom.xml
+++ b/qa.qanary_component-QueryBuilder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.wdaqua.qanary.component</groupId>
     <artifactId>qa.qanary_component-QueryBuilder</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
@@ -13,7 +13,7 @@
     </parent>
     <properties>
         <java.version>11</java.version>
-        <qanary.version>[2.0.0,3.0.0)</qanary.version>
+        <qanary.version>[2.1.1,3.0.0)</qanary.version>
         <docker.image.prefix>qanary</docker.image.prefix>
         <docker.image.name>query-builder</docker.image.name>
         <dockerfile-maven-version>1.4.13</dockerfile-maven-version>
@@ -65,6 +65,18 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path-assert</artifactId>
             <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>[2.15.0,3.)</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
@anbo-de 

I have completed the changes to the last components (#120).  For the two components "DiambiguationClass-OKBQA" and "DiambiguationProperty-OKBQA" log4j is used in the components themselves, I have removed this by comment for now.  I'm not quite sure why the log level was set directly in the source code, can you please look at this again.