### PR TITLE
Preliminary introduction of input/output data specifications for the components

### DIFF
--- a/qa.qanary_component-QueryBuilder/README.md
+++ b/qa.qanary_component-QueryBuilder/README.md
@@ -1,0 +1,76 @@
+# Query Builder
+
+## Description
+
+Receives 3 optional data structures: AnnotationOfClass, AnnotationOfRelation, and AnnotationOfInstance. Depending on the availability of them, generates a query over DBpedia and stores it.
+
+## Input specification
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+
+<urn:qanary:input> a qa:AnnotationOfClass .
+<urn:qanary:input> oa:hasTarget [
+    a oa:SpecificResource ;
+    oa:hasSource ?q ;
+];
+    oa:hasBody ?uri .
+```
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+
+<urn:qanary:input> a qa:AnnotationOfRelation .
+<urn:qanary:input> oa:hasTarget [
+    a oa:SpecificResource ;
+    oa:hasSource ?q ;
+];
+    oa:hasBody ?uri .
+```
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+
+<urn:qanary:input> a qa:AnnotationOfInstance .
+<urn:qanary:input> oa:hasTarget [
+    a    oa:SpecificResource;
+        oa:hasSource ?q ;
+        oa:hasSelector  [
+            a oa:TextPositionSelector ;
+            oa:start "0"^^xsd:nonNegativeInteger ;
+            oa:end  "5"^^xsd:nonNegativeInteger
+        ]
+    ] .
+<urn:qanary:input> oa:hasBody <dbr:Resource> .
+```
+
+## Output specification
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+
+<urn:qanary:output> a qa:AnnotationOfAnswerSPARQL ;
+    oa:hasTarget <answerID> ;
+    oa:hasBody "sparql query" ;
+    oa:annotatedAt "2001-10-26T21:32:52"^^xsd:dateTime ;
+    oa:annotatedBy <urn:qanary:QB#applicationName > .
+```
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<urn:qanary:output> a qa:AnnotationOfAnswerJson ;
+    oa:hasTarget <answerID> ;
+    oa:hasBody "jsonString"^^xsd:string ;
+    oa:annotatedBy <urn:qanary:QB#applicationName > ;
+    oa:annotatedAt "2001-10-26T21:32:52"^^xsd:dateTime .
+
+# in SparqlExecuter ?answer a qa:AnswerJson is used
+```

--- a/qa.qanary_component-QueryBuilder/README.md
+++ b/qa.qanary_component-QueryBuilder/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Receives 3 optional data structures: AnnotationOfClass, AnnotationOfRelation, and AnnotationOfInstance. Depending on the availability of them, generates a query over DBpedia and stores it.
+Receives 3 optional data structures: `AnnotationOfClass`, `AnnotationOfRelation`, and `AnnotationOfInstance`. Depending on the availability of them, generates a query over DBpedia and stores it.
 
 ## Input specification
 
@@ -12,9 +12,9 @@ Receives 3 optional data structures: AnnotationOfClass, AnnotationOfRelation, an
 
 <urn:qanary:input> a qa:AnnotationOfClass .
 <urn:qanary:input> oa:hasTarget [
-    a oa:SpecificResource ;
-    oa:hasSource ?q ;
-];
+        a oa:SpecificResource ;
+        oa:hasSource ?q ;
+    ];
     oa:hasBody ?uri .
 ```
 
@@ -24,9 +24,9 @@ Receives 3 optional data structures: AnnotationOfClass, AnnotationOfRelation, an
 
 <urn:qanary:input> a qa:AnnotationOfRelation .
 <urn:qanary:input> oa:hasTarget [
-    a oa:SpecificResource ;
-    oa:hasSource ?q ;
-];
+        a oa:SpecificResource ;
+        oa:hasSource ?q ;
+    ];
     oa:hasBody ?uri .
 ```
 
@@ -36,7 +36,7 @@ Receives 3 optional data structures: AnnotationOfClass, AnnotationOfRelation, an
 
 <urn:qanary:input> a qa:AnnotationOfInstance .
 <urn:qanary:input> oa:hasTarget [
-    a    oa:SpecificResource;
+    a   oa:SpecificResource;
         oa:hasSource ?q ;
         oa:hasSelector  [
             a oa:TextPositionSelector ;
@@ -71,6 +71,6 @@ Receives 3 optional data structures: AnnotationOfClass, AnnotationOfRelation, an
     oa:hasBody "jsonString"^^xsd:string ;
     oa:annotatedBy <urn:qanary:QB#applicationName > ;
     oa:annotatedAt "2001-10-26T21:32:52"^^xsd:dateTime .
-
-# in SparqlExecuter ?answer a qa:AnswerJson is used
 ```
+
+Remark: in SparqlExecuter `?answer a qa:AnswerJson` is used

--- a/qanary_component-NED-DBpedia-Spotlight/README.md
+++ b/qanary_component-NED-DBpedia-Spotlight/README.md
@@ -7,7 +7,7 @@ Receives a textual question, forwards it to DBpedia Spotlight API and writes res
 ## Input specification
 
 ```ttl
-None
+# TODO: get textual representation of question
 ```
 
 ## Output specification
@@ -18,7 +18,7 @@ None
 
 <urn:qanary:output> a qa:AnnotationOfInstance .
 <urn:qanary:output> oa:hasTarget [
-    a    oa:SpecificResource;
+    a   oa:SpecificResource;
         oa:hasSource    <urn:qanary:myQanaryQuestion> ;
         oa:hasSelector  [
             a oa:TextPositionSelector ;
@@ -29,6 +29,5 @@ None
 <urn:qanary:output> oa:hasBody <dbr:Resource> ;
     oa:annotatedBy <urn:qanary:myDBpediaSpotlightConfiguration:getEndpoint> ;
     oa:annotatedAt "2001-10-26T21:32:52"^^xsd:dateTime ;
-    qa:score "0.5"^^xsd:decimal . "
-}
+    qa:score "0.5"^^xsd:decimal .
 ```

--- a/qanary_component-NED-DBpedia-Spotlight/README.md
+++ b/qanary_component-NED-DBpedia-Spotlight/README.md
@@ -1,0 +1,34 @@
+# NED DBpedia Spotlight
+
+## Description
+
+Receives a textual question, forwards it to DBpedia Spotlight API and writes result in JSON format.
+
+## Input specification
+
+```ttl
+None
+```
+
+## Output specification
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+
+<urn:qanary:output> a qa:AnnotationOfInstance .
+<urn:qanary:output> oa:hasTarget [
+    a    oa:SpecificResource;
+        oa:hasSource    <urn:qanary:myQanaryQuestion> ;
+        oa:hasSelector  [
+            a oa:TextPositionSelector ;
+            oa:start "0"^^xsd:nonNegativeInteger ;
+            oa:end  "5"^^xsd:nonNegativeInteger
+        ]
+    ] .
+<urn:qanary:output> oa:hasBody <dbr:Resource> ;
+    oa:annotatedBy <urn:qanary:myDBpediaSpotlightConfiguration:getEndpoint> ;
+    oa:annotatedAt "2001-10-26T21:32:52"^^xsd:dateTime ;
+    qa:score "0.5"^^xsd:decimal . "
+}
+```

--- a/qanary_component-QB-ComicCharacterAlterEgoSimpleDBpediaQueryBuilder/README.md
+++ b/qanary_component-QB-ComicCharacterAlterEgoSimpleDBpediaQueryBuilder/README.md
@@ -6,7 +6,7 @@ Receives a disambiguated entity and builds a SPARQL query over Wikidata about al
 
 ## Input specification
 
-Comment: non standard type `qa:AnnotationOfSpotInstance` is used
+Comment: non-standard type `qa:AnnotationOfSpotInstance` is used
 
 ```ttl
 @prefix qa: <http://www.wdaqua.eu/qa#> .
@@ -35,9 +35,9 @@ Comment: complex `oa:hasTarget` is used
 
 <urn:qanary:output> a qa:AnnotationOfAnswerSPARQL ;
     oa:hasTarget [
-		a    oa:SpecificResource ;
+	    a    oa:SpecificResource ;
 	    oa:hasSource    <urn:qanary:qanaryQuestion.getUri> ;
-	] ;
+    ] ;
     oa:hasBody "sparql query" ;
     qa:score "0.5"^^xsd:float ;
     oa:annotatedAt "2001-10-26T21:32:52"^^xsd:dateTime ;

--- a/qanary_component-QB-ComicCharacterAlterEgoSimpleDBpediaQueryBuilder/README.md
+++ b/qanary_component-QB-ComicCharacterAlterEgoSimpleDBpediaQueryBuilder/README.md
@@ -1,0 +1,45 @@
+# QB ComicCharacterAlterEgoSimpleQueryBuilder component
+
+## Description
+
+Receives a disambiguated entity and builds a SPARQL query over Wikidata about all the data related to birth of an entity
+
+## Input specification
+
+Comment: non standard type `qa:AnnotationOfSpotInstance` is used
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+
+<urn:qanary:input> a qa:AnnotationOfSpotInstance .
+<urn:qanary:input> oa:hasTarget [
+    a    oa:SpecificResource;
+    oa:hasSource    <urn:qanary:myQanaryQuestion> ;
+    oa:hasSelector  [
+        a oa:TextPositionSelector ;
+        oa:start "0"^^xsd:nonNegativeInteger ;
+        oa:end  "5"^^xsd:nonNegativeInteger
+    ]
+] .
+<urn:qanary:input> oa:annotatedAt "2001-10-26T21:32:52"^^xsd:dateTime .
+```
+
+## Output specification
+
+Comment: complex `oa:hasTarget` is used
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+
+<urn:qanary:output> a qa:AnnotationOfAnswerSPARQL ;
+    oa:hasTarget [
+		a    oa:SpecificResource ;
+	    oa:hasSource    <urn:qanary:qanaryQuestion.getUri> ;
+	] ;
+    oa:hasBody "sparql query" ;
+    qa:score "0.5"^^xsd:float ;
+    oa:annotatedAt "2001-10-26T21:32:52"^^xsd:dateTime ;
+    oa:annotatedBy <urn:qanary:applicationName > .
+```

--- a/qanary_component-QB-SimpleRealNameOfSuperHero/README.md
+++ b/qanary_component-QB-SimpleRealNameOfSuperHero/README.md
@@ -18,8 +18,8 @@ This rule-based Qanary component is intended to create a SPARQL query that can b
         a oa:TextPositionSelector ;
         oa:start "0"^^xsd:nonNegativeInteger ;
         oa:end  "5"^^xsd:nonNegativeInteger
-      ]
-  ] .
+   ]
+] .
 ```
 
 ## Output specification
@@ -39,12 +39,14 @@ This rule-based Qanary component is intended to create a SPARQL query that can b
 ## Example 
 
 ### Question of the Qanary process
+
 ```
 What is the real name of Captain America?
 ```
 
 ### Expected SPARQL query to be stored in the Qanary triplestore
-```
+
+```sparql
 PREFIX dbr: <http://dbpedia.org/resource/>
 PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
@@ -72,6 +74,7 @@ ORDER BY ?resource
 
 The component stores the result (the aforementioned SPARQL query) into the `body oa:hasBody` of an annotation of type `qa:AnnotationOfAnswerSPARQL`. 
 The following SPARQL query to retrieve this information from the Qanary triplestore:
+
 ```sparql
 PREFIX oa: <http://www.w3.org/ns/openannotation/core/>
 PREFIX qa: <http://www.wdaqua.eu/qa#> 
@@ -90,10 +93,13 @@ WHERE {
 ### Build with Maven
 
 Like all Qanary component created using the [Qanary Maven archetype](https://github.com/WDAqua/Qanary/tree/master/qanary-component-archetype) it can be built using the following commands:
+
 ```
 mvn package
 ```
+
 To exclude the building of a corresponding Docker container use:
+
 ```
 mvn package -DskipDockerBuild 
 ```
@@ -101,7 +107,9 @@ mvn package -DskipDockerBuild
 ### Run 
 
 To run the JAR file directly use (`X.Y.Z` refers to the current version of the component):
-```
+
+```shell
 java -jar target/qanary_component-QB-SimpleRealNameOfSuperHero-X.Y.Z.jar
 ```
+
 While using the Docker image, start the image `qanary_component-QB-SimpleRealNameOfSuperHero`.

--- a/qanary_component-QB-SimpleRealNameOfSuperHero/README.md
+++ b/qanary_component-QB-SimpleRealNameOfSuperHero/README.md
@@ -1,6 +1,40 @@
-# A simple QueryBuilder component w.r.t. Superhero Names
+# QB SimpleRealNameOfSuperHero component
 
 This rule-based Qanary component is intended to create a SPARQL query that can be executed on DBpedia for the limited knowledge domain of superhero names.
+
+
+## Input specification
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+
+<urn:qanary:input> oa:hasBody <dbr:Resource> ;
+  qa:score "0.5"^^xsd:decimal ;
+  oa:hasTarget [
+    a    oa:SpecificResource;
+    oa:hasSource    <urn:qanary:myQanaryQuestion> ;
+    oa:hasSelector  [
+        a oa:TextPositionSelector ;
+        oa:start "0"^^xsd:nonNegativeInteger ;
+        oa:end  "5"^^xsd:nonNegativeInteger
+      ]
+  ] .
+```
+
+## Output specification
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+
+<urn:qanary:output> a qa:AnnotationOfAnswerSPARQL ;
+    oa:hasTarget <urn:qanary:myQanaryQuestion> ;
+    oa:hasBody "sparql query" ;
+    qa:score "0.5"^^xsd:float ;
+    oa:annotatedAt "2001-10-26T21:32:52"^^xsd:dateTime ;
+    oa:annotatedBy <urn:qanary:applicationName > .
+```
 
 ## Example 
 

--- a/qanary_component-QB-Sina/README.md
+++ b/qanary_component-QB-Sina/README.md
@@ -1,0 +1,64 @@
+# QB SINA component
+
+Receives 3 data structures: AnnotationOfClass, AnnotationOfRelation, and AnnotationOfInstance. Depending on the availability of them, generates a query and stores it.
+
+## Input specification
+
+Comment: `qa:AnnotationOfInstance` does not have `oa:annotatedAt`
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+
+<urn:qanary:input> a qa:AnnotationOfClass .
+<urn:qanary:input> oa:hasTarget [
+    a oa:SpecificResource ;
+    oa:hasSource ?q ;
+];
+    oa:hasBody ?uri ;
+    oa:annotatedAt "2001-10-26T21:32:52"^^xsd:dateTime .
+```
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+
+<urn:qanary:input> a qa:AnnotationOfRelation .
+<urn:qanary:input> oa:hasTarget [
+    a oa:SpecificResource ;
+    oa:hasSource ?q ;
+];
+    oa:hasBody ?uri ;
+    oa:annotatedAt "2001-10-26T21:32:52"^^xsd:dateTime .
+```
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+
+<urn:qanary:input> a qa:AnnotationOfInstance .
+<urn:qanary:input> oa:hasTarget [
+    a    oa:SpecificResource;
+        oa:hasSource ?q ;
+        oa:hasSelector  [
+            a oa:TextPositionSelector ;
+            oa:start "0"^^xsd:nonNegativeInteger ;
+            oa:end  "5"^^xsd:nonNegativeInteger
+        ]
+    ] .
+<urn:qanary:input> oa:hasBody <dbr:Resource> .
+```
+
+## Output specification
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+
+<urn:qanary:output> a qa:AnnotationOfAnswerSPARQL ;
+    oa:hasTarget <urn:qanary:myQanaryQuestion> ;
+    oa:hasBody "sparql query" ;
+    qa:score "0.5"^^xsd:float ;
+    oa:annotatedAt "2001-10-26T21:32:52"^^xsd:dateTime ;
+    oa:annotatedBy <urn:qanary:applicationName > .
+```

--- a/qanary_component-QB-Sina/README.md
+++ b/qanary_component-QB-Sina/README.md
@@ -1,6 +1,6 @@
 # QB SINA component
 
-Receives 3 data structures: AnnotationOfClass, AnnotationOfRelation, and AnnotationOfInstance. Depending on the availability of them, generates a query and stores it.
+Receives 3 data structures: `AnnotationOfClass`, `AnnotationOfRelation`, and `AnnotationOfInstance`. Depending on the availability of them, generates a query and stores it.
 
 ## Input specification
 
@@ -12,9 +12,9 @@ Comment: `qa:AnnotationOfInstance` does not have `oa:annotatedAt`
 
 <urn:qanary:input> a qa:AnnotationOfClass .
 <urn:qanary:input> oa:hasTarget [
-    a oa:SpecificResource ;
-    oa:hasSource ?q ;
-];
+        a oa:SpecificResource ;
+        oa:hasSource ?q ;
+    ]; 
     oa:hasBody ?uri ;
     oa:annotatedAt "2001-10-26T21:32:52"^^xsd:dateTime .
 ```
@@ -25,9 +25,9 @@ Comment: `qa:AnnotationOfInstance` does not have `oa:annotatedAt`
 
 <urn:qanary:input> a qa:AnnotationOfRelation .
 <urn:qanary:input> oa:hasTarget [
-    a oa:SpecificResource ;
-    oa:hasSource ?q ;
-];
+        a oa:SpecificResource ;
+        oa:hasSource ?q ;
+    ];
     oa:hasBody ?uri ;
     oa:annotatedAt "2001-10-26T21:32:52"^^xsd:dateTime .
 ```
@@ -38,7 +38,7 @@ Comment: `qa:AnnotationOfInstance` does not have `oa:annotatedAt`
 
 <urn:qanary:input> a qa:AnnotationOfInstance .
 <urn:qanary:input> oa:hasTarget [
-    a    oa:SpecificResource;
+    a   oa:SpecificResource;
         oa:hasSource ?q ;
         oa:hasSelector  [
             a oa:TextPositionSelector ;

--- a/qanary_component-QBE-QAnswer/README.md
+++ b/qanary_component-QBE-QAnswer/README.md
@@ -11,6 +11,74 @@ Consequently, your request to the QAnswer API might be more precise.
 [QAnswer](https://www.qanswer.eu/) is an API capable of retrieving data from different knowledge graphs.
 An example is available at [https://qanswer-frontend.univ-st-etienne.fr/](https://qanswer-frontend.univ-st-etienne.fr/).
 
+## Input specification
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+
+<urn:qanary:input> a qa:AnnotationOfInstance ;
+  oa:hasTarget [
+    a oa:SpecificResource ;
+    oa:hasSource <urn:qanary:myQanaryQuestion> ;
+    oa:hasSelector  [
+        a oa:TextPositionSelector ;
+        oa:start "0"^^xsd:nonNegativeInteger ;
+        oa:end "5"^^xsd:nonNegativeInteger
+    ]
+  ] ;
+  oa:hasBody <wd:Resource> .
+```
+
+## Output specification
+
+Comment: sparql query is stored as a complex structure; `annotationOfAnswerType` is never used
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+
+?annotationSPARQL a 	qa:AnnotationOfAnswerSPARQL ;
+	oa:hasTarget    <urn:qanary:myQanaryQuestion> ;
+	oa:hasBody      ?sparql  ;
+	oa:annotatedBy  <urn:qanary:applicationName> ;
+	oa:annotatedAt  "2001-10-26T21:32:52"^^xsd:dateTime ;
+	qa:score        "0.5"^^xsd:double .
+
+?sparql a              qa:SparqlQuery ;
+  rdf:value       ?sparqlQueryString .
+
+?annotationImprovedQuestion  a 	qa:AnnotationOfImprovedQuestion ;
+	oa:hasTarget    <urn:qanary:myQanaryQuestion> ;
+	oa:hasBody      ?improvedQuestion ;
+	oa:annotatedBy  <urn:qanary:applicationName> ;
+	oa:annotatedAt  "2001-10-26T21:32:52"^^xsd:dateTime ;
+	qa:score        "0.5"^^xsd:double .
+  
+?improvedQuestion a    qa:ImprovedQuestion ;
+  rdf:value "improved question text"^^xsd:string .
+
+?annotationAnswer a    qa:AnnotationAnswer ;
+  oa:hasTarget    <urn:qanary:myQanaryQuestion> ;
+  oa:hasBody      ?answer ;
+	oa:annotatedBy  <urn:qanary:applicationName> ;
+	oa:annotatedAt  "2001-10-26T21:32:52"^^xsd:dateTime ;
+	qa:score        "0.5"^^xsd:double .
+
+?answer a qa:Answer ;
+  rdf:value       [ a rdf:Seq wd:Resource, wd:Resource1 ]  .
+
+?annotationAnswerType a qa:AnnotationOfAnswerType ;
+  oa:hasTarget    <urn:qanary:myQanaryQuestion> ;
+  oa:hasBody      ?annotationOfAnswerType ;
+	oa:annotatedBy  <urn:qanary:applicationName> ;
+	oa:annotatedAt  "2001-10-26T21:32:52"^^xsd:dateTime ;
+	qa:score        "0.5"^^xsd:double .
+
+?answerType a qa:AnswerType ;
+  rdf:value <xsd:dataType> ;
+```
+
 ## Examples
 
 ### Example 1: What is the capital of Germany?

--- a/qanary_component-QBE-QAnswer/README.md
+++ b/qanary_component-QBE-QAnswer/README.md
@@ -32,7 +32,7 @@ An example is available at [https://qanswer-frontend.univ-st-etienne.fr/](https:
 
 ## Output specification
 
-Comment: sparql query is stored as a complex structure; `annotationOfAnswerType` is never used
+Comment: the SPARQL query is stored as a complex structure; `annotationOfAnswerType` is never used
 
 ```ttl
 @prefix qa: <http://www.wdaqua.eu/qa#> .
@@ -45,8 +45,8 @@ Comment: sparql query is stored as a complex structure; `annotationOfAnswerType`
 	oa:annotatedAt  "2001-10-26T21:32:52"^^xsd:dateTime ;
 	qa:score        "0.5"^^xsd:double .
 
-?sparql a              qa:SparqlQuery ;
-  rdf:value       ?sparqlQueryString .
+?sparql a               qa:SparqlQuery ;
+  	rdf:value       ?sparqlQueryString .
 
 ?annotationImprovedQuestion  a 	qa:AnnotationOfImprovedQuestion ;
 	oa:hasTarget    <urn:qanary:myQanaryQuestion> ;
@@ -56,27 +56,29 @@ Comment: sparql query is stored as a complex structure; `annotationOfAnswerType`
 	qa:score        "0.5"^^xsd:double .
   
 ?improvedQuestion a    qa:ImprovedQuestion ;
-  rdf:value "improved question text"^^xsd:string .
+  	rdf:value "improved question text"^^xsd:string .
 
 ?annotationAnswer a    qa:AnnotationAnswer ;
-  oa:hasTarget    <urn:qanary:myQanaryQuestion> ;
-  oa:hasBody      ?answer ;
+  	oa:hasTarget    <urn:qanary:myQanaryQuestion> ;
+  	oa:hasBody      ?answer ;
 	oa:annotatedBy  <urn:qanary:applicationName> ;
 	oa:annotatedAt  "2001-10-26T21:32:52"^^xsd:dateTime ;
 	qa:score        "0.5"^^xsd:double .
 
 ?answer a qa:Answer ;
-  rdf:value       [ a rdf:Seq wd:Resource, wd:Resource1 ]  .
+	rdf:value [ 
+	  	a rdf:Seq wd:Resource, wd:Resource1 
+	] .
 
 ?annotationAnswerType a qa:AnnotationOfAnswerType ;
-  oa:hasTarget    <urn:qanary:myQanaryQuestion> ;
-  oa:hasBody      ?annotationOfAnswerType ;
+ 	oa:hasTarget    <urn:qanary:myQanaryQuestion> ;
+  	oa:hasBody      ?annotationOfAnswerType ;
 	oa:annotatedBy  <urn:qanary:applicationName> ;
 	oa:annotatedAt  "2001-10-26T21:32:52"^^xsd:dateTime ;
 	qa:score        "0.5"^^xsd:double .
 
 ?answerType a qa:AnswerType ;
-  rdf:value <xsd:dataType> ;
+ 	rdf:value <xsd:dataType> ;
 ```
 
 ## Examples
@@ -123,10 +125,14 @@ SELECT * FROM <YOURGRAPHURI> WHERE {
     ?s ?p ?o ; 
         a ?type. 
     VALUES ?t { 
-        qa:AnnotationOfAnswerSPARQL qa:SparqlQuery
-        qa:AnnotationOfImprovedQuestion qa:ImprovedQuestion 
-        qa:AnnotationAnswer qa:Answer 
-        qa:AnnotationOfAnswerType qa:AnswerType 
+        qa:AnnotationOfAnswerSPARQL 
+	qa:SparqlQuery
+        qa:AnnotationOfImprovedQuestion 
+	qa:ImprovedQuestion 
+        qa:AnnotationAnswer 
+	qa:Answer 
+        qa:AnnotationOfAnswerType 
+	qa:AnswerType 
     }
 }
 ORDER BY ?type

--- a/qanary_component-QE-SparqlExecuter/README.md
+++ b/qanary_component-QE-SparqlExecuter/README.md
@@ -1,0 +1,34 @@
+# QE SparqlExecuter component
+
+## Description
+
+Receives a SPARQL query over DBpedia or Wikidata, executes it and writes result in JSON format.
+
+## Input specification
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+
+<urn:qanary:input> a qa:AnnotationOfAnswerSPARQL ;
+   oa:hasBody "sparql query over dbpedia or wikidata" ;
+   oa:annotatedAt "2001-10-26T21:32:52"^^xsd:dateTime .
+```
+
+## Output specification
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<urn:qanary:output> a qa:AnnotationOfAnswerJson ;
+    oa:hasTarget <urn:qanary:myQuestionUri> ;
+    oa:hasBody ?answer ;
+    oa:annotatedBy <urn:qanary:applicationName> ;
+    oa:annotatedAt "2001-10-26T21:32:52"^^xsd:dateTime .
+?answer a qa:AnswerJson ;
+    rdf:value "jsonString"^^xsd:string  .
+qa:AnswerJson rdfs:subClassOf qa:Answer .
+```

--- a/qanary_component-qb-birthdata-wikidata/README.md
+++ b/qanary_component-qb-birthdata-wikidata/README.md
@@ -1,0 +1,42 @@
+# QB BirthData Wikidata component
+
+## Description
+
+Receives a disambiguated entity and builds a SPARQL query over Wikidata about all the data related to birth of an entity
+
+## Input specification
+
+Comment: missing `<urn:qanary:input> a qa:AnnotationOfInstance .`
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+
+<urn:qanary:input> oa:hasBody <wd:Resource> ;
+    qa:score "score"^^xsd:decimal .
+<urn:qanary:input> oa:hasTarget [
+    a    oa:SpecificResource;
+    oa:hasSource <urn:qanary:myQuestionURI> ;
+    oa:hasSelector  [
+        a oa:TextPositionSelector ;
+        oa:start "0"^^xsd:nonNegativeInteger ;
+        oa:end  "5"^^xsd:nonNegativeInteger
+    ]
+] .
+```
+
+## Output specification
+
+Comment: `qa:score` is `xsd:float` while in the ontology it is [decimal](https://github.com/WDAqua/QAOntology/blob/6d25ebc8970b93452b5bb970a8e2f526be9841a5/qanary.ttl#L31)
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+
+<urn:qanary:output> a qa:AnnotationOfAnswerSPARQL ;
+    oa:hasTarget <urn:qanary:myQuestionURI> ;
+    oa:hasBody "sparql query" ;
+    qa:score "0.5"^^xsd:float ;
+    oa:annotatedAt "2001-10-26T21:32:52"^^xsd:dateTime ;
+    oa:annotatedBy <urn:qanary:QB#applicationName > .
+```

--- a/qanary_component-qe-wikidata/README.md
+++ b/qanary_component-qe-wikidata/README.md
@@ -1,0 +1,37 @@
+# QE Wikidata component
+
+## Description
+
+Receives a SPARQL query over Wikidata, executes it and writes result in JSON format.
+
+## Input specification
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+
+<urn:qanary:input> a qa:AnnotationOfAnswerSPARQL ;
+   oa:hasTarget <urn:qanary:myQuestionUri> ;
+   oa:hasBody "sparql query over dbpedia or wikidata" ;
+   oa:annotatedAt "2001-10-26T21:32:52"^^xsd:dateTime ;
+   qa:score "0.5"^^xsd:float .
+```
+
+## Output specification
+
+```ttl
+@prefix qa: <http://www.wdaqua.eu/qa#> .
+@prefix oa: <http://www.w3.org/ns/openannotation/core/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<urn:qanary:output> a qa:AnnotationOfAnswerJson ;
+    oa:hasTarget <urn:qanary:myQuestionUri> ;
+    oa:hasBody ?answer ;
+    oa:annotatedBy <urn:qanary:applicationName> ;
+    oa:annotatedAt "2001-10-26T21:32:52"^^xsd:dateTime .
+    qa:score "0.5"^^xsd:float .
+?answer a qa:AnswerJson ;
+    rdf:value "jsonString"^^xsd:string  .
+qa:AnswerJson rdfs:subClassOf qa:Answer .
+```


### PR DESCRIPTION
Currently QB/QE components are covered completely. For each component, `README.md` file was added/edited s.t. it has `## Input specification` and `## Output specification` headers. There, data specifications are written in `ttl` format.