### PR TITLE
Update for Log4j fix

### DIFF
--- a/qanary_component-NER-DBpedia-Spotlight/src/main/java/eu/wdaqua/qanary/dbpediaSpotlight/DBpediaSpotlightNER.java
+++ b/qanary_component-NER-DBpedia-Spotlight/src/main/java/eu/wdaqua/qanary/dbpediaSpotlight/DBpediaSpotlightNER.java
@@ -122,7 +122,6 @@ public class DBpediaSpotlightNER extends QanaryComponent {
 
     public QanaryMessage process(QanaryMessage myQanaryMessage) {
         long startTime = System.currentTimeMillis();
-        org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.OFF);
         logger.info("Qanary Message: {}", myQanaryMessage);
 
         try {

--- a/qanary_component-NER-FOX/src/main/java/eu/wdaqua/qanary/FOX/FOXComponent.java
+++ b/qanary_component-NER-FOX/src/main/java/eu/wdaqua/qanary/FOX/FOXComponent.java
@@ -44,7 +44,6 @@ public class FOXComponent extends QanaryComponent {
      */
     public QanaryMessage process(QanaryMessage myQanaryMessage) throws Exception {
         long startTime = System.currentTimeMillis();
-        org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.OFF);
         logger.info("Qanary Message: {}", myQanaryMessage);
 
         // STEP1: Retrieve the named graph and the endpoint

--- a/qanary_component-NERD-Lucene-Linker/src/main/java/eu/wdaqua/qanary/LuceneLinker/LuceneLinker.java
+++ b/qanary_component-NERD-Lucene-Linker/src/main/java/eu/wdaqua/qanary/LuceneLinker/LuceneLinker.java
@@ -57,7 +57,6 @@ public class LuceneLinker extends QanaryComponent {
      */
     public QanaryMessage process(QanaryMessage myQanaryMessage) {
         long startTime = System.currentTimeMillis();
-        org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.OFF);
         logger.info("Qanary Message: {}", myQanaryMessage);
 
         try {

--- a/qanary_component-QC-EAT-classifier/pom.xml
+++ b/qanary_component-QC-EAT-classifier/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eu.wdaqua.qanary.component</groupId>
 	<artifactId>qanary_component_answer-type-classifier</artifactId>
-	<version>0.1.1</version>
+	<version>0.1.2</version>
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -14,7 +14,7 @@
 	</parent>
 	<properties>
 		<java.version>11</java.version>
-		<qanary.version>[2.0.0,3.0.0)</qanary.version>
+		<qanary.version>[2.1.1,3.0.0)</qanary.version>
 		<spring-boot-admin.version>2.1.6</spring-boot-admin.version>
 		<docker.image.prefix>qanary</docker.image.prefix>
 		<!-- Replace the name of the docker image to be generated -->
@@ -75,6 +75,17 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             </dependency>
+ 		<dependency>
+		    <groupId>org.apache.logging.log4j</groupId>
+		    <artifactId>log4j-to-slf4j</artifactId>
+		    <version>[2.15.0,3.)</version>
+					<exclusions>
+						<exclusion>
+							<groupId>org.apache.logging.log4j</groupId>
+							<artifactId>log4j-api</artifactId>
+						</exclusion>
+					</exclusions>
+		</dependency>
     </dependencies>
 	<build>
 		<plugins>


### PR DESCRIPTION
Remove hard-coded log level from components NER-DBpedia-Spotlight, NER-FOX and NERD-Lucene-Linker.

Implement fix for component QC-EAT-classifier.