### PR TITLE
Fix tiny mistake in SPARQL of QB-QAnswer and bump version

### DIFF
--- a/qanary_component-QB-QAnswer/pom.xml
+++ b/qanary_component-QB-QAnswer/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eu.wdaqua.qanary.component</groupId>
 	<artifactId>qanary-component-qb-qanswer</artifactId>
-	<version>0.1.0</version>
+	<version>0.1.1</version>
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>

--- a/qanary_component-QB-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qb/QAnswerQueryBuilderAndSparqlResultFetcher.java
+++ b/qanary_component-QB-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qb/QAnswerQueryBuilderAndSparqlResultFetcher.java
@@ -339,7 +339,8 @@ public class QAnswerQueryBuilderAndSparqlResultFetcher extends QanaryComponent {
 					+ "  ?sparql" + counter + " a              qa:SparqlQuery ; \n" //
 					+ "         qa:hasPosition  \"" + counter + "\"^^xsd:nonNegativeInteger ; \n" // 
 					+ "         rdf:value       \"\"\"" + answer.get("query").getAsString() + "\"\"\"^^xsd:string . \n"; //
-			bindForInsert += "  BIND (IRI(str(RAND())) AS ?annotationSPARQL" + counter + ") . \n"; //
+			bindForInsert += "  BIND (IRI(str(RAND())) AS ?annotationSPARQL" + counter + ") . \n" //
+					+ "  BIND (IRI(str(RAND())) AS ?sparql" + counter + ") . \n"; //
 
 			counter++;
 		}


### PR DESCRIPTION
The annotations of SPARQL were not saving because no `BIND` statement was introduced to them, eg:
`BIND (IRI(str(RAND())) AS ?sparql0) . `