### PR TITLE
60 standardize naming

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,24 @@
+name: Qanary Component Build Pipeline
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Docker Login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: actions/checkout@v3
+      - name: Build the Docker images and Push to Dockerhub
+        run: bash -c ./service_config/build_images.sh
+      - name: Init update
+        env:
+          API_KEY: ${{ secrets.API_KEY }}
+          UPDATER_HOST: ${{ secrets.UPDATER_HOST }}
+        run: cd service_config && python init_services.py update

--- a/service_config/build_images.sh
+++ b/service_config/build_images.sh
@@ -1,7 +1,19 @@
 #!/bin/bash
+# clone Qanary pipeline
+git clone https://github.com/WDAqua/Qanary.git
+
+# subshell building the Qanary pipeline
+(
+cd Qanary/
+mvn clean install -Ddockerfile.skip=true -DskipTests
+)
+
+# delete Qanary pipeline repository
+rm -rf Qanary/
+
 # build Docker Images and store name and tag
 mvn clean package -DskipTests
-docker image ls | grep -oP "qanary.*\.[0-9] " > images.temp
+docker image ls | grep -oP "^qanary/qanary-component.*\.[0-9] " > images.temp
 
 # read image list
 images=$(cat images.temp)
@@ -26,10 +38,9 @@ do
     i=0
 
     # tag images and push to Dockerhub
-    docker tag "${file_name}" "qanary/${file_name}"
-    docker tag "${file_name}" "qanary/${latest_file_name}"
-    docker push "qanary/${file_name}"
-    docker push "qanary/${latest_file_name}"
+    docker tag "${file_name}" "${latest_file_name}"
+    docker push "${file_name}"
+    docker push "${latest_file_name}"
   fi
 done
 

--- a/service_config/build_images.sh
+++ b/service_config/build_images.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# build Docker Images and store name and tag
+mvn clean package -DskipTests
+docker image ls | grep -oP "qanary.*\.[0-9] " > images.temp
+
+# read image list
+images=$(cat images.temp)
+
+i=0
+
+# for each image
+for row in $images
+do
+  # row contains the image name
+  if [ $i -eq 0 ]
+  then
+    # store image name
+    file_name=$row
+    i=$((i + 1))
+  # row contains tag
+  else
+    # generate version and latest tag
+    latest_file_name="${file_name}:latest"
+    file_name="${file_name}:${row}"
+
+    i=0
+
+    # tag images and push to Dockerhub
+    docker tag "${file_name}" "qanary/${file_name}"
+    docker tag "${file_name}" "qanary/${latest_file_name}"
+    docker push "qanary/${file_name}"
+    docker push "qanary/${latest_file_name}"
+  fi
+done
+
+# delete temp results
+rm images.temp

--- a/service_config/config.py
+++ b/service_config/config.py
@@ -1,0 +1,11 @@
+import re
+
+modes = [
+    'docker',
+    'docker-compose',
+    'dockerfile'
+]
+
+
+def check_ports(port: str):
+    return re.match(r'^\d+:\d+$', port)

--- a/service_config/files/asr-kaldi
+++ b/service_config/files/asr-kaldi
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40120
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40120

--- a/service_config/files/cls-clsnliod
+++ b/service_config/files/cls-clsnliod
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40121
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40121

--- a/service_config/files/ld-shuyo
+++ b/service_config/files/ld-shuyo
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40122
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40122

--- a/service_config/files/ned-agdistis
+++ b/service_config/files/ned-agdistis
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40123
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40123

--- a/service_config/files/ned-ambiverse
+++ b/service_config/files/ned-ambiverse
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40124
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40124

--- a/service_config/files/ned-aylien
+++ b/service_config/files/ned-aylien
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40125
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40125

--- a/service_config/files/ned-babelfy
+++ b/service_config/files/ned-babelfy
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40126
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40126

--- a/service_config/files/ned-dandelion
+++ b/service_config/files/ned-dandelion
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40128
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40128

--- a/service_config/files/ned-dbpediaspotlight
+++ b/service_config/files/ned-dbpediaspotlight
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40127
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40127

--- a/service_config/files/ned-diambiguationclass-okbqa
+++ b/service_config/files/ned-diambiguationclass-okbqa
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40129
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40129

--- a/service_config/files/ned-meaningcloud
+++ b/service_config/files/ned-meaningcloud
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40130
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40130

--- a/service_config/files/ned-opentapioca
+++ b/service_config/files/ned-opentapioca
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40131
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40131

--- a/service_config/files/ned-tagme
+++ b/service_config/files/ned-tagme
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40132
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40132

--- a/service_config/files/ned-watson
+++ b/service_config/files/ned-watson
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40133
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40133

--- a/service_config/files/ner-ambiverse
+++ b/service_config/files/ner-ambiverse
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40134
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40134

--- a/service_config/files/ner-aylien
+++ b/service_config/files/ner-aylien
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40135
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40135

--- a/service_config/files/ner-babelfy
+++ b/service_config/files/ner-babelfy
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40136
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40136

--- a/service_config/files/ner-comiccharacternamesimplenamedentityrecognizer
+++ b/service_config/files/ner-comiccharacternamesimplenamedentityrecognizer
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40137
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40137

--- a/service_config/files/ner-dandelion
+++ b/service_config/files/ner-dandelion
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40139
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40139

--- a/service_config/files/ner-dbpediaspotlight
+++ b/service_config/files/ner-dbpediaspotlight
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40138
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40138

--- a/service_config/files/ner-entityclassifier
+++ b/service_config/files/ner-entityclassifier
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40140
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40140

--- a/service_config/files/ner-entityclassifier2
+++ b/service_config/files/ner-entityclassifier2
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40141
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40141

--- a/service_config/files/ner-fox
+++ b/service_config/files/ner-fox
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40142
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40142

--- a/service_config/files/ner-meaning-cloud
+++ b/service_config/files/ner-meaning-cloud
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40143
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40143

--- a/service_config/files/ner-ontotext
+++ b/service_config/files/ner-ontotext
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40144
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40144

--- a/service_config/files/ner-stanford
+++ b/service_config/files/ner-stanford
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40145
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40145

--- a/service_config/files/ner-tagme
+++ b/service_config/files/ner-tagme
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40146
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40146

--- a/service_config/files/ner-text-razor
+++ b/service_config/files/ner-text-razor
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40147
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40147

--- a/service_config/files/nerd-alchemy
+++ b/service_config/files/nerd-alchemy
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40148
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40148

--- a/service_config/files/nerd-lucenelinker
+++ b/service_config/files/nerd-lucenelinker
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40149
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40149

--- a/service_config/files/nerd-smaph
+++ b/service_config/files/nerd-smaph
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40150
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40150

--- a/service_config/files/qb-annotationofspotclass-okbqa
+++ b/service_config/files/qb-annotationofspotclass-okbqa
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40151
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40151

--- a/service_config/files/qb-birthdatawikidata
+++ b/service_config/files/qb-birthdatawikidata
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40152
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40152

--- a/service_config/files/qb-comiccharacteralteregosimpledbpedia
+++ b/service_config/files/qb-comiccharacteralteregosimpledbpedia
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40153
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40153

--- a/service_config/files/qb-monolithicwrapper
+++ b/service_config/files/qb-monolithicwrapper
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40154
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40154

--- a/service_config/files/qb-qanswer
+++ b/service_config/files/qb-qanswer
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40155
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40155

--- a/service_config/files/qb-simplerealnameofsuperhero
+++ b/service_config/files/qb-simplerealnameofsuperhero
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40156
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40156

--- a/service_config/files/qb-sina
+++ b/service_config/files/qb-sina
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40157
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40157

--- a/service_config/files/qbe-qanswer
+++ b/service_config/files/qbe-qanswer
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40158
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40158

--- a/service_config/files/qbe-simplequerybuilderandexecutor
+++ b/service_config/files/qbe-simplequerybuilderandexecutor
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40160
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40160

--- a/service_config/files/qc-answertypeclassifier
+++ b/service_config/files/qc-answertypeclassifier
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40161
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40161

--- a/service_config/files/qe-sparqlexecuter
+++ b/service_config/files/qe-sparqlexecuter
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40162
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40162

--- a/service_config/files/qe-wikidata
+++ b/service_config/files/qe-wikidata
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40163
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40163

--- a/service_config/files/rd-annotaitonofspotproperty-okbqa
+++ b/service_config/files/rd-annotaitonofspotproperty-okbqa
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40164
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40164

--- a/service_config/files/rd-diambiguationproperty-okbqa
+++ b/service_config/files/rd-diambiguationproperty-okbqa
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40165
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40165

--- a/service_config/files/rel-relationlinker1
+++ b/service_config/files/rel-relationlinker1
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40168
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40168

--- a/service_config/files/rel-relationlinker2
+++ b/service_config/files/rel-relationlinker2
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40169
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40169

--- a/service_config/files/rel-relniod
+++ b/service_config/files/rel-relniod
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40167
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40167

--- a/service_config/files/rel-rematch
+++ b/service_config/files/rel-rematch
@@ -1,0 +1,4 @@
+SERVER_HOST=http://demos.swe.htwk-leipzig.de
+SERVER_PORT=40166
+SPRING_BOOT_ADMIN_URL=http://demos.swe.htwk-leipzig.de:40111/
+SPRING_BOOT_ADMIN_CLIENT_INSTANCE_SERVICE-BASE-URL=http://demos.swe.htwk-leipzig.de:40166

--- a/service_config/init_services.py
+++ b/service_config/init_services.py
@@ -1,0 +1,93 @@
+import requests
+import json
+from os import environ
+import sys
+from copy import deepcopy
+
+# run configuration not provided
+if len(sys.argv) != 2:
+    print('Please specify mode "register" or "update" or "delete"')
+    sys.exit(-1)
+# invalid run configuration provided
+elif sys.argv[1] not in ['register', 'update', 'delete']:
+    print('Please specify mode "register" or "update"')
+    sys.exit(-2)
+
+mode = sys.argv[1]
+
+# load service configuration
+with open('service_config.json') as f:
+    initialization_configuration = json.load(f)
+
+# load microservice updater configuration
+host = environ['UPDATER_HOST']
+api_key = environ['API_KEY']
+
+# for each service configuration
+for i, service in enumerate(initialization_configuration['services']):
+    service['API-KEY'] = api_key
+
+    # read all related files and add them to the payload
+    if 'files' in service:
+        keep = deepcopy(service['files'])
+
+        for file in service['files']:
+            with open(f'files/{service["files"][file]}') as f:
+                service['files'][file] = f.read()
+    else:
+        keep = {}
+
+    # register new service
+    if mode == 'register':
+        response = requests.post(f'{host}/service', json=service, headers={'Content-Type': 'application/json'},
+                                 verify=False)
+
+        # registration successful
+        if response.ok:
+            print(f'service {i} registered successfully.', response.text)
+
+            # store service_id for later updates or deletions
+            if 'ids' not in initialization_configuration:
+                initialization_configuration['ids'] = {}
+
+            initialization_configuration['ids'][str(i)] = response.json()['id']
+        # registration failed
+        else:
+            print(f'registration of service {i} failed:', response.text)
+    # update service
+    elif mode == 'update':
+        if 'ids' in initialization_configuration:
+            # send update request
+            response = requests.post(f'{host}/service/{initialization_configuration["ids"][str(i)]}',
+                                     json=service, headers={'Content-Type': 'application/json'}, verify=False)
+
+            # update initiated successfully
+            if response.ok:
+                print(f'service {i} update initiated successfully.', response.text)
+            # update initiation failed
+            else:
+                print(f'service {i} update failed.', response.text)
+    # delete service
+    elif mode == 'delete':
+        if 'ids' in initialization_configuration:
+            # send delete request
+            response = requests.delete(f'{host}/service/{initialization_configuration["ids"][str(i)]}',
+                                       json=service, headers={'Content-Type': 'application/json'}, verify=False)
+
+            # deletion successful
+            if response.ok:
+                print(f'service {i} deleted.', response.text)
+
+                # delete id from configuration
+                initialization_configuration['ids'].pop(str(i))
+            else:
+                print(f'service {i} deletion failed!', response.text)
+
+    service['files'] = keep
+
+    # remove API key from configuration
+    service.pop('API-KEY')
+
+# store updated configuration
+with open('service_config.json', 'w') as f:
+    json.dump(initialization_configuration, f, indent=2)

--- a/service_config/service_config.json
+++ b/service_config/service_config.json
@@ -1,0 +1,126 @@
+{
+  "services": [
+    {
+      "mode": "dockerfile",
+      "port": "40122:40122",
+      "image": "qanary/qanary-component-ld-shuyo",
+      "tag": "latest",
+      "files": {
+        ".env": "ld-shuyo"
+      }
+    },
+    {
+      "mode": "dockerfile",
+      "port": "40127:40127",
+      "image": "qanary/qanary-component-ned-dbpediaspotlight",
+      "tag": "latest",
+      "files": {
+        ".env": "ned-dbpediaspotlight"
+      }
+    },
+    {
+      "mode": "dockerfile",
+      "port": "40131:40131",
+      "image": "qanary/qanary-component-ned-opentapioca",
+      "tag": "latest",
+      "files": {
+        ".env": "ned-opentapioca"
+      }
+    },
+    {
+      "mode": "dockerfile",
+      "port": "40137:40137",
+      "image": "qanary/qanary-component-ner-comiccharacternamesimplenamedentityrecognizer",
+      "tag": "latest",
+      "files": {
+        ".env": "ner-comiccharacternamesimplenamedentityrecognizer"
+      }
+    },
+    {
+      "mode": "dockerfile",
+      "port": "40161:40161",
+      "image": "qanary/qanary-component-qc-answertypeclassifier",
+      "tag": "latest",
+      "files": {
+        ".env": "qc-answertypeclassifier"
+      }
+    },
+    {
+      "mode": "dockerfile",
+      "port": "40152:40152",
+      "image": "qanary/qanary-component-qb-birthdatawikidata",
+      "tag": "latest",
+      "files": {
+        ".env": "qb-birthdatawikidata"
+      }
+    },
+    {
+      "mode": "dockerfile",
+      "port": "40153:40153",
+      "image": "qanary/qanary-component-qb-comiccharacteralteregosimpledbpedia",
+      "tag": "latest",
+      "files": {
+        ".env": "qb-comiccharacteralteregosimpledbpedia"
+      }
+    },
+    {
+      "mode": "dockerfile",
+      "port": "40155:40155",
+      "image": "qanary/qanary-component-qb-qanswer",
+      "tag": "latest",
+      "files": {
+        ".env": "qb-qanswer"
+      }
+    },
+    {
+      "mode": "dockerfile",
+      "port": "40158:40158",
+      "image": "qanary/qanary-component-qbe-qanswer",
+      "tag": "latest",
+      "files": {
+        ".env": "qbe-qanswer"
+      }
+    },
+    {
+      "mode": "dockerfile",
+      "port": "40156:40156",
+      "image": "qanary/qanary-component-qb-simplerealnameofsuperhero",
+      "tag": "latest",
+      "files": {
+        ".env": "qb-simplerealnameofsuperhero"
+      }
+    },
+    {
+      "mode": "dockerfile",
+      "port": "40162:40162",
+      "image": "qanary/qanary-component-qe-sparqlexecuter",
+      "tag": "latest",
+      "files": {
+        ".env": "qe-sparqlexecuter"
+      }
+    },
+    {
+      "mode": "dockerfile",
+      "port": "40163:40163",
+      "image": "qanary/qanary-component-qe-wikidata",
+      "tag": "latest",
+      "files": {
+        ".env": "qe-wikidata"
+      }
+    }
+  ],
+  "ids": {
+    "0": "qanary-qanary-component-ld-shuyo",
+    "1": "qanary-qanary-component-ned-dbpediaspotlight",
+    "2": "qanary-qanary-component-ned-opentapioca",
+    "3": "qanary-qanary-component-ner-comiccharacternamesimplenamedentityrecognizer",
+    "4": "qanary-qanary-component-qc-answertypeclassifier",
+    "5": "qanary-qanary-component-qb-birthdatawikidata",
+    "6": "qanary-qanary-component-qb-comiccharacteralteregosimpledbpedia",
+    "7": "qanary-qanary-component-qb-qanswer",
+    "8": "qanary-qanary-component-qbe-qanswer",
+    "9": "qanary-qanary-component-qb-simplerealnameofsuperhero",
+    "10": "qanary-qanary-component-qe-sparqlexecuter",
+    "11": "qanary-qanary-component-qe-wikidata"
+  }
+}


### PR DESCRIPTION
# Motivation
This pull request enables an automated update process for all Qanary components. All images will be build automatically and pushed to Docker Hub. Although, there is a subset of components running on a demo server, which will be updated with each commit to the `master` branch. To finish the configuration it is necessary that a maintainer adds the following secrets to the repository and pushes the missing docker images to Docker Hub.

# Needed Configuration
- [ ] Providing all repository secrets:
  - [ ] DOCKER_USER := username of the Docker Hub account maintaining the Qanary components images
  - [ ] DOCKER_PASSWORD := access token for the Docker Hub account
  - [ ] API_KEY := API key used  by the [microservice updater](https://github.com/MindMaster98/microservice-updater)
  - [ ] UPDATER_HOST := https://demos.swe.htwk-leipzig.de:40195

- [x] Provide all docker images
  - [x] qanary/qanary-component-ld-shuyo:latest
  - [x] qanary/qanary-component-qe-wikidata:latest
  - [x] qanary/qanary-component-ned-dbpediaspotlight:latest
  - [x] qanary/qanary-component-ned-opentapioca:latest
  - [x] qanary/qanary-component-ner-comiccharacternamesimplenamedentityrecognizer:latest
  - [x] qanary/qanary-component-qc-answertypeclassifier:latest
  - [x] qanary/qanary-component-qb-birthdatawikidata:latest
  - [x] qanary/qanary-component-qb-comiccharacteralteregosimpledbpedia:latest
  - [x] qanary/qanary-component-qe-sparqlexecuter:latest
  - [x] qanary/qanary-component-qe-wikidata:latest