### PR TITLE
Adding support for Java 17 on GitHub Action

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Configure java
-      - uses: actions/setup-java@v3
+        uses: actions/setup-java@v3
         with:
           distribution: 'corretto'
           java-version: '17'

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,6 +9,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Configure java
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '17'
       - name: Docker Login
         uses: docker/login-action@v2
         with:

--- a/qanary-component-ASR-Kaldi/Dockerfile
+++ b/qanary-component-ASR-Kaldi/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-CLS-CLSNLIOD/Dockerfile
+++ b/qanary-component-CLS-CLSNLIOD/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-LD-Shuyo/Dockerfile
+++ b/qanary-component-LD-Shuyo/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NED-AGDISTIS/Dockerfile
+++ b/qanary-component-NED-AGDISTIS/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NED-Ambiverse/Dockerfile
+++ b/qanary-component-NED-Ambiverse/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NED-Aylien/Dockerfile
+++ b/qanary-component-NED-Aylien/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NED-Babelfy/Dockerfile
+++ b/qanary-component-NED-Babelfy/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NED-DBpediaSpotlight/Dockerfile
+++ b/qanary-component-NED-DBpediaSpotlight/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NED-Dandelion/Dockerfile
+++ b/qanary-component-NED-Dandelion/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NED-DiambiguationClass-OKBQA/Dockerfile
+++ b/qanary-component-NED-DiambiguationClass-OKBQA/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NED-MeaningCloud/Dockerfile
+++ b/qanary-component-NED-MeaningCloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NED-Ontotext/Dockerfile
+++ b/qanary-component-NED-Ontotext/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NED-Opentapioca/Dockerfile
+++ b/qanary-component-NED-Opentapioca/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM openjdk:11                                                                                                                                                                                                                             
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NED-Tagme/Dockerfile
+++ b/qanary-component-NED-Tagme/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NED-Watson/Dockerfile
+++ b/qanary-component-NED-Watson/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NER-Ambiverse/Dockerfile
+++ b/qanary-component-NER-Ambiverse/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NER-Aylien/Dockerfile
+++ b/qanary-component-NER-Aylien/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NER-Babelfy/Dockerfile
+++ b/qanary-component-NER-Babelfy/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NER-ComicCharacterNameSimpleNamedEntityRecognizer/Dockerfile
+++ b/qanary-component-NER-ComicCharacterNameSimpleNamedEntityRecognizer/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NER-DBpediaSpotlight/Dockerfile
+++ b/qanary-component-NER-DBpediaSpotlight/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NER-Dandelion/Dockerfile
+++ b/qanary-component-NER-Dandelion/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NER-EntityClassifier/Dockerfile
+++ b/qanary-component-NER-EntityClassifier/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NER-EntityClassifier2/Dockerfile
+++ b/qanary-component-NER-EntityClassifier2/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NER-FOX/Dockerfile
+++ b/qanary-component-NER-FOX/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NER-MeaningCloud/Dockerfile
+++ b/qanary-component-NER-MeaningCloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NER-Ontotext/Dockerfile
+++ b/qanary-component-NER-Ontotext/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NER-Stanford/Dockerfile
+++ b/qanary-component-NER-Stanford/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NER-Tagme/Dockerfile
+++ b/qanary-component-NER-Tagme/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NER-TextRazor/Dockerfile
+++ b/qanary-component-NER-TextRazor/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NERD-Alchemy/Dockerfile
+++ b/qanary-component-NERD-Alchemy/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NERD-LuceneLinker/Dockerfile
+++ b/qanary-component-NERD-LuceneLinker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-NERD-SMAPH/Dockerfile
+++ b/qanary-component-NERD-SMAPH/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-QB-AnnotationOfSpotClass-OKBQA/Dockerfile
+++ b/qanary-component-QB-AnnotationOfSpotClass-OKBQA/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-QB-BirthDataWikidata/Dockerfile
+++ b/qanary-component-QB-BirthDataWikidata/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM openjdk:11                                                                                                                                                                                                                             
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-QB-ComicCharacterAlterEgoSimpleDBpedia/Dockerfile
+++ b/qanary-component-QB-ComicCharacterAlterEgoSimpleDBpedia/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-QB-GAnswerWrapper/Dockerfile
+++ b/qanary-component-QB-GAnswerWrapper/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM openjdk:11                                                                                                                                                                                                                             
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-QB-MonoliticWrapper/Dockerfile
+++ b/qanary-component-QB-MonoliticWrapper/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-QB-PlatypusWrapper/Dockerfile
+++ b/qanary-component-QB-PlatypusWrapper/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM openjdk:11                                                                                                                                                                                                                             
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-QB-QAnswer/Dockerfile
+++ b/qanary-component-QB-QAnswer/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM openjdk:11                                                                                                                                                                                                                             
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-QB-RuBQWrapper/Dockerfile
+++ b/qanary-component-QB-RuBQWrapper/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM openjdk:11                                                                                                                                                                                                                             
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-QB-SimpleRealNameOfSuperHero/Dockerfile
+++ b/qanary-component-QB-SimpleRealNameOfSuperHero/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-QB-Sina/Dockerfile
+++ b/qanary-component-QB-Sina/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-QB-TeBaQaWrapper/Dockerfile
+++ b/qanary-component-QB-TeBaQaWrapper/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM openjdk:11                                                                                                                                                                                                                             
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-QBE-QAnswer/Dockerfile
+++ b/qanary-component-QBE-QAnswer/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM openjdk:11                                                                                                                                                                                                                             
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-QBE-SimpleQueryBuilderAndExecutor/Dockerfile
+++ b/qanary-component-QBE-SimpleQueryBuilderAndExecutor/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-QC-AnswerTypeClassifier/Dockerfile
+++ b/qanary-component-QC-AnswerTypeClassifier/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM openjdk:11                                                                                                                                                                                                                             
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-QE-SparqlExecuter/Dockerfile
+++ b/qanary-component-QE-SparqlExecuter/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-QE-Wikidata/Dockerfile
+++ b/qanary-component-QE-Wikidata/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM openjdk:11                                                                                                                                                                                                                             
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-RD-AnnotaitonOfSpotProperty-OKBQA/Dockerfile
+++ b/qanary-component-RD-AnnotaitonOfSpotProperty-OKBQA/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-RD-DiambiguationProperty-OKBQA/Dockerfile
+++ b/qanary-component-RD-DiambiguationProperty-OKBQA/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-REL-ReMatch/Dockerfile
+++ b/qanary-component-REL-ReMatch/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-REL-RelNliod/Dockerfile
+++ b/qanary-component-REL-RelNliod/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-REL-RelationLinker1/Dockerfile
+++ b/qanary-component-REL-RelationLinker1/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE

--- a/qanary-component-REL-RelationLinker2/Dockerfile
+++ b/qanary-component-REL-RelationLinker2/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 
 # Add the service itself
 ARG JAR_FILE


### PR DESCRIPTION
This Pull Request adds the support for java 17 on the GitHub Actions Pipeline for automated building of Qanary components as well as the Docker Images of each component. 