### PR TITLE
Add both QAnswer components to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,8 @@
                 <module>qanary-component-NED-Opentapioca</module>
                 <module>qanary-component-QB-BirthDataWikidata</module>
                 <module>qanary-component-QE-Wikidata</module>
-		<!-- <module>qanary-component-QBE-QAnswer</module> -->
-		<!-- <module>qanary-component-QB-QAnswer</module> -->
+		<module>qanary-component-QBE-QAnswer</module>
+		<module>qanary-component-QB-QAnswer</module>
                 <module>qanary-component-QB-PlatypusWrapper</module>
                 <module>qanary-component-QB-GAnswerWrapper</module>
                 <module>qanary-component-QB-RuBQWrapper</module>


### PR DESCRIPTION
I added both QAnswer components to pom.xml because without it the docker images aren't built with `mvn clean package -DskipTests`