### PR TITLE
Update QAnswer components

### DIFF
--- a/qanary-component-QB-QAnswer/README.md
+++ b/qanary-component-QB-QAnswer/README.md
@@ -13,7 +13,6 @@ Consequently, your request to the QAnswer API might be more precise.
 ## Background
 
 [QAnswer](https://www.qanswer.eu/) is an API capable of retrieving data from different knowledge graphs.
-An example is available at [https://qanswer-frontend.univ-st-etienne.fr/](https://qanswer-frontend.univ-st-etienne.fr/).
 
 ## Examples
 

--- a/qanary-component-QB-QAnswer/pom.xml
+++ b/qanary-component-QB-QAnswer/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.wdaqua.qanary.component</groupId>
     <artifactId>qanary-component-QB-QAnswer</artifactId>
-    <version>3.1.6</version>
+    <version>4.0.0</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -13,7 +13,7 @@
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <qanary.version>[3.7.1,4.0.0)</qanary.version>
         <spring-boot-admin.version>2.7.10</spring-boot-admin.version>
         <docker.image.prefix>qanary</docker.image.prefix>

--- a/qanary-component-QB-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qb/QAnswerQueryBuilderAndSparqlResultFetcherController.java
+++ b/qanary-component-QB-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qb/QAnswerQueryBuilderAndSparqlResultFetcherController.java
@@ -1,8 +1,10 @@
 package eu.wdaqua.qanary.component.qanswer.qb;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -151,14 +153,21 @@ public class QAnswerQueryBuilderAndSparqlResultFetcherController {
 					+ "\"Is Berlin the capital of Germany\" " //
 	)
 	public QAnswerQanaryWrapperResult requestDemoResultWebService(@RequestBody QAnswerRequest request)
-			throws URISyntaxException, MalformedURLException, QanaryExceptionNoOrMultipleQuestions, SparqlQueryFailed {
+			throws URISyntaxException, QanaryExceptionNoOrMultipleQuestions, SparqlQueryFailed, IOException {
 		logger.info("requestDemoResultWebService: {} ", request);
 		request.replaceNullValuesWithDefaultValues(this.getEndpoint(), this.getLangFallback(),
 				this.getKnowledgeBaseDefault(), this.getUserDefault());
 		QAnswerResult result = this.requestQAnswerWebService(request);
-		String sparqQuery = myQAnswerQueryBuilderAndExecutor.getSparqlInsertQuery(endpoint, result);
+
+		URI demoGraph = new URI("urn:demo:graph");
+		URI demoQuestionUri = new URI("urn:demo:question");
+
+		String sparqlImprovedQuestion = myQAnswerQueryBuilderAndExecutor.getSparqlInsertQueryForImprovedQuestion(demoGraph, demoQuestionUri, result);
+		List<String> sparqlQueryCandidates = myQAnswerQueryBuilderAndExecutor.getSparqlInsertQueriesForQueryCandidates(demoGraph, demoQuestionUri, result);
+
+		String sparqQuery = "this is a test query";
 		logger.info("received sparqQuery: {}", sparqQuery);
-		return new QAnswerQanaryWrapperResult(result, sparqQuery);
+		return new QAnswerQanaryWrapperResult(result, sparqlImprovedQuestion, sparqlQueryCandidates);
 	}
 	
 	

--- a/qanary-component-QB-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qb/messages/ProcessedResult.java
+++ b/qanary-component-QB-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qb/messages/ProcessedResult.java
@@ -3,6 +3,7 @@ package eu.wdaqua.qanary.component.qanswer.qb.messages;
 import java.net.URI;
 import java.util.List;
 
+@Deprecated
 public class ProcessedResult {
 
 	private final String type;

--- a/qanary-component-QB-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qb/messages/QAnswerQanaryWrapperResult.java
+++ b/qanary-component-QB-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qb/messages/QAnswerQanaryWrapperResult.java
@@ -1,20 +1,28 @@
 package eu.wdaqua.qanary.component.qanswer.qb.messages;
 
+import java.util.List;
+
 public class QAnswerQanaryWrapperResult {
 
     private final QAnswerResult result;
-    private final String sparqlQuery;
+    private final String sparqlImprovedQuestion;
+    private final List<String> sparqlQueryCandidates;
 
-    public QAnswerQanaryWrapperResult(QAnswerResult result, String sparqQuery) {
+    public QAnswerQanaryWrapperResult(QAnswerResult result, String sparqlImprovedQuestion, List<String> sparqlQueryCandidates) {
         this.result = result;
-        this.sparqlQuery = sparqQuery;
+        this.sparqlImprovedQuestion = sparqlImprovedQuestion;
+        this.sparqlQueryCandidates = sparqlQueryCandidates;
     }
 
     public QAnswerResult getResult() {
         return result;
     }
 
-    public String getSparqlQuery() {
-        return sparqlQuery;
+    public String getSparqlImprovedQuestion() {
+        return sparqlImprovedQuestion;
+    }
+
+    public List<String> getSparqlQueryCandidates() {
+        return sparqlQueryCandidates;
     }
 }

--- a/qanary-component-QB-QAnswer/src/main/resources/config/application.properties
+++ b/qanary-component-QB-QAnswer/src/main/resources/config/application.properties
@@ -23,8 +23,6 @@ logging.level.org.springframework.test:WARN
 logging.level.eu.wdaqua.qanary:DEBUG
 spring.mvc.converters.preferred-json-mapper=gson
 # define the API endpoint of the QAnswer API
-#qanswer.endpoint.url=http://qanswer-core1.univ-st-etienne.fr/api/gerbil
-# https://qanswer-core1.univ-st-etienne.fr/api/qa/full?question={question}&lang={lang}&kb={kb}&user=open
 qanswer.endpoint.url=https://qanswer-core1.univ-st-etienne.fr/api/qa/full
 # define the minimum required confidence (property: `qa:score`) for named entities (otherwise they are ignored)
 qanswer.qbe.namedentities.threshold=0.5

--- a/qanary-component-QB-QAnswer/src/test/java/eu/wdaqua/qanary/component/qanswer/qb/QAnswerQueryBuilderAndSpaqlResultFetcherTest.java
+++ b/qanary-component-QB-QAnswer/src/test/java/eu/wdaqua/qanary/component/qanswer/qb/QAnswerQueryBuilderAndSpaqlResultFetcherTest.java
@@ -1,8 +1,16 @@
 package eu.wdaqua.qanary.component.qanswer.qb;
 
-import eu.wdaqua.qanary.communications.RestTemplateWithCaching;
-import eu.wdaqua.qanary.component.qanswer.qb.messages.QAnswerResult;
-import net.minidev.json.parser.ParseException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,14 +25,9 @@ import org.springframework.test.context.junit.jupiter.EnabledIf;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.RestTemplate;
 
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.LinkedList;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import eu.wdaqua.qanary.communications.RestTemplateWithCaching;
+import eu.wdaqua.qanary.component.qanswer.qb.messages.QAnswerResult;
+import eu.wdaqua.qanary.component.qanswer.qb.messages.QAnswerResult.QAnswerQueryCandidate;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Application.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -45,17 +48,9 @@ class QAnswerQueryBuilderAndSpaqlResultFetcherTest {
 
     private URI realEndpoint;
 
-    private URI resource;
-    private URI bool;
-    private URI decimal;
-
     @BeforeEach
     public void init() throws URISyntaxException {
         realEndpoint = new URI(env.getProperty("qanswer.endpoint.url"));
-
-        bool = new URI("http://www.w3.org/2001/XMLSchema#boolean");
-        decimal = new URI("http://www.w3.org/2001/XMLSchema#decimal");
-        resource = new URI("http://www.w3.org/2001/XMLSchema#anyURI");
 
         assert (realEndpoint != null) : "qanswer.endpoint.url cannot be empty";
 
@@ -65,7 +60,7 @@ class QAnswerQueryBuilderAndSpaqlResultFetcherTest {
     }
 
     @Test
-    void testTransformationOfNamedEntites() throws URISyntaxException {
+    void testComputeQuestionStringWithReplacedResourcesDBpedia() throws URISyntaxException {
         float threshold = 0.5f;
         QAnswerQueryBuilderAndSparqlResultFetcher myApp = new QAnswerQueryBuilderAndSparqlResultFetcher(threshold, "en", "dbpedia", "open",
                 new URI("urn:no:endpoint"), applicationName, restTemplate);
@@ -75,6 +70,30 @@ class QAnswerQueryBuilderAndSpaqlResultFetcherTest {
         URI parisUri = new URI("http://dbpedia.org/resource/Paris");
         URI londonUri = new URI("http://dbpedia.org/resource/London");
         URI germanyUri = new URI("http://dbpedia.org/resource/Germany");
+        String givenQuestion = "Where are Paris, London and Germany?";
+        String expectedResult = "Where are " + parisUri + " , " + londonUri + " and " + germanyUri + " ?";
+        myTestData.add(new TestData(givenQuestion, expectedResult, entities0));
+        entities0.add(new NamedEntity(parisUri, 10, "Paris", threshold));
+        entities0.add(new NamedEntity(londonUri, 17, "London", threshold));
+        entities0.add(new NamedEntity(germanyUri, 28, "Germany", threshold + 0.001f));
+
+        // TODO: add more test data
+
+        checkTestData(myTestData, threshold, myApp);
+    }
+
+    @Test
+    void testComputeQuestionStringWithReplacedResourcesWikidata() throws URISyntaxException {
+        float threshold = 0.5f;
+        QAnswerQueryBuilderAndSparqlResultFetcher myApp = new QAnswerQueryBuilderAndSparqlResultFetcher(threshold, "en", "dbpedia", "open",
+                new URI("urn:no:endpoint"), applicationName, restTemplate);
+        List<TestData> myTestData = new LinkedList<>();
+
+        List<NamedEntity> entities0 = new LinkedList<>();
+        URI parisUri = getWikidataURI("90");
+        URI londonUri = getWikidataURI("Q84");
+        URI germanyUri = getWikidataURI("Q183");
+
         String givenQuestion = "Where are Paris, London and Germany?";
         String expectedResult = "Where are " + parisUri + " , " + londonUri + " and " + germanyUri + " ?";
         myTestData.add(new TestData(givenQuestion, expectedResult, entities0));
@@ -132,20 +151,11 @@ class QAnswerQueryBuilderAndSpaqlResultFetcherTest {
         return new URI("http://www.wikidata.org/entity/" + id);
     }
 
-    /**
-     * test actual results from the QAnswer API with question 'What is the capital
-     * of Germany?' --> one resource
-     *
-     * @throws URISyntaxException
-     * @throws ParseException
-     * @throws NoLiteralFieldFoundException
-     * @throws MalformedURLException
-     */
     @Test
     @EnabledIf(
             expression = "#{environment['test.live.endpoints'] == 'true'}", //
             loadContext = true)    
-    void testWebServiceWhatIsTheCapitalOfGermanyResultOneResource() throws URISyntaxException, ParseException, MalformedURLException {
+    void testWebServiceWithOriginalQuestionString() throws URISyntaxException, MalformedURLException {
         float threshold = 0.4f;
         String lang = "en";
         String kb = "wikidata";
@@ -154,89 +164,40 @@ class QAnswerQueryBuilderAndSpaqlResultFetcherTest {
         QAnswerQueryBuilderAndSparqlResultFetcher myApp = new QAnswerQueryBuilderAndSparqlResultFetcher(threshold, lang, kb, user,
                 this.realEndpoint, applicationName, restTemplate);
         String question = "What is the capital of Germany?";
-        QAnswerResult result0 = testWebService(myApp, question, lang, kb, user);
 
-        URI germanyUri = getWikidataURI("Q183");
-        String expectedQuestion = "What is the capital of " + germanyUri.toString() + " ?";
-
-        List<NamedEntity> entities0 = new LinkedList<>();
-        entities0.add(new NamedEntity(germanyUri, 23, "Germany", threshold + 0.001f));
-        String computedQuestion = myApp.computeQuestionStringWithReplacedResources(question, entities0, threshold);
-
-        // check correct transformation of the given question
-        assertEquals(expectedQuestion, computedQuestion, //
-                "From '" + question + "' it was expected '" + expectedQuestion //
-                        + "' but computed '" + computedQuestion + "'");
-
-        //
-        QAnswerResult result1 = testWebService(myApp, computedQuestion, lang, kb, user);
-
+        // check if there is at least one result query candidate
+        testWebService(myApp, question, lang, kb, user);
     }
 
-    /**
-     * test actual results from the QAnswer API with question 'Cities in France?'
-     * --> many resources
-     *
-     * @throws URISyntaxException
-     * @throws ParseException
-     * @throws NoLiteralFieldFoundException
-     * @throws MalformedURLException
-     */
     @Test
     @EnabledIf(
             expression = "#{environment['test.live.endpoints'] == 'true'}", //
-            loadContext = true)
-    void testWebServicePersonBornInFranceResultManyResources() throws URISyntaxException, ParseException, MalformedURLException {
+            loadContext = true)    
+    void testWebServiceWithReplacedResources() throws URISyntaxException, MalformedURLException {
         float threshold = 0.4f;
         String lang = "en";
         String kb = "wikidata";
         String user = "open";
-        int min = 2;
-        int max = 60;
 
-        // test while using a plain textual question
         QAnswerQueryBuilderAndSparqlResultFetcher myApp = new QAnswerQueryBuilderAndSparqlResultFetcher(threshold, lang, kb, user,
                 this.realEndpoint, applicationName, restTemplate);
-        String question = "Person born in France.";
-        QAnswerResult result0 = testWebService(myApp, question, lang, kb, user);
-
 
         // test with question enriched with a Wikidata entity
         URI franceUri = getWikidataURI("Q142");
-        String expectedQuestion = "Person born in " + franceUri.toString() + " .";
+        String qString = "Person born in " + franceUri.toString() + " .";
+        // note: the functionality of computeQuestionStringWithReplacedResources() 
+        //      is already tested in its own unit test, and can therefore be assumed!
 
-        List<NamedEntity> entities0 = new LinkedList<>();
-        entities0.add(new NamedEntity(franceUri, 15, "France", threshold + 0.001f));
-        String computedQuestion = myApp.computeQuestionStringWithReplacedResources(question, entities0, threshold);
-
-
-        // check if transformation of the given question was correct
-        assertEquals(expectedQuestion, computedQuestion, //
-                "From '" + question + "' it was expected '" + expectedQuestion //
-                        + "' but computed '" + computedQuestion + "'");
-
-        // Note: we do not know the exact number of SPALQL queries provided by QAnswer
-        QAnswerResult result1 = testWebService(myApp, computedQuestion, lang, kb, user);
-
-        assertTrue(result1.getValues().size() >= min, "problem: not " + result1.getValues().size() + " >= " + min);
-        assertTrue(result1.getValues().size() <= max, "problem: not " + result1.getValues().size() + " <= " + max);
+        // check if there is at least one result query candidate
+        testWebService(myApp, qString, lang, kb, user);
 
     }
 
-    /**
-     * test actual results from the QAnswer API with question 'Is Berlin the capital
-     * of Germany' --> many resources
-     *
-     * @throws URISyntaxException
-     * @throws ParseException
-     * @throws NoLiteralFieldFoundException
-     * @throws MalformedURLException
-     */
     @Test
     @EnabledIf(
             expression = "#{environment['test.live.endpoints'] == 'true'}", //
-            loadContext = true)
-    void testWebServiceIsBerlinTheCapitalOfGermanyResultBoolean() throws URISyntaxException, ParseException, MalformedURLException {
+            loadContext = true)    
+    void testWebServiceResourceQuestionResultsInSparqlSelectQuery () throws MalformedURLException, URISyntaxException {
         float threshold = 0.4f;
         String lang = "en";
         String kb = "wikidata";
@@ -245,43 +206,24 @@ class QAnswerQueryBuilderAndSpaqlResultFetcherTest {
         QAnswerQueryBuilderAndSparqlResultFetcher myApp = new QAnswerQueryBuilderAndSparqlResultFetcher(threshold, lang, kb, user,
                 this.realEndpoint, applicationName, restTemplate);
         String question = "Is Berlin the capital of Germany";
-        QAnswerResult result0 = testWebService(myApp, question, lang, kb, user);
 
-        URI berlinUri = getWikidataURI("Q64");
-        String expectedQuestion = "Is " + berlinUri.toString() + " the capital of Germany";
-
-        List<NamedEntity> entities0 = new LinkedList<>();
-        entities0.add(new NamedEntity(berlinUri, 3, "Berlin", threshold + 0.001f));
-        String computedQuestion = myApp.computeQuestionStringWithReplacedResources(question, entities0, threshold);
-        // computedQuestion = "http://dbpedia.org/resource/United_Kingdom
-        // http://dbpedia.org/ontology/capital http://dbpedia.org/resource/London";
-
-		/*
-		// check correct transformation of the given question
-		assertEquals("From '" + question + "' it was expected '" + expectedQuestion //
-				+ "' but computed '" + computedQuestion + "'", //
-				expectedQuestion, computedQuestion);
-		*/
-        QAnswerResult result1 = testWebService(myApp, computedQuestion, lang, kb, user);
-
-        // TODO: test for a ASK SPARQL query
-
+        // check if the query candidates contain at least one ASK type query
+        QAnswerResult result = testWebService(myApp, question, lang, kb, user);
+        for (QAnswerQueryCandidate queryCandidate : result.getQueryCandidates()) {
+            Query query = QueryFactory.create(queryCandidate.getQueryString());
+            if (query.isSelectType()) {
+                assert(true);
+                return;
+            } 
+        }
+        assert(false);
     }
 
-    /**
-     * test actual results from the QAnswer API with question 'What is the capital
-     * of Germany?' --> one resource
-     *
-     * @throws URISyntaxException
-     * @throws ParseException
-     * @throws NoLiteralFieldFoundException
-     * @throws MalformedURLException
-     */
     @Test
     @EnabledIf(
             expression = "#{environment['test.live.endpoints'] == 'true'}", //
-            loadContext = true)
-    void testWebServicePopulationOfFranceResultNumber() throws URISyntaxException, ParseException, MalformedURLException {
+            loadContext = true)    
+    void testWebServiceBooleanQuestionResultsInSparqlAskQuery() throws MalformedURLException, URISyntaxException {
         float threshold = 0.4f;
         String lang = "en";
         String kb = "wikidata";
@@ -289,60 +231,25 @@ class QAnswerQueryBuilderAndSpaqlResultFetcherTest {
 
         QAnswerQueryBuilderAndSparqlResultFetcher myApp = new QAnswerQueryBuilderAndSparqlResultFetcher(threshold, lang, kb, user,
                 this.realEndpoint, applicationName, restTemplate);
-        String question = "population of france";
-        QAnswerResult result0 = testWebService(myApp, question, lang, kb, user);
+        String question = "Is Berlin the capital of Germany";
 
-        URI everestUri = getWikidataURI("Q142");
-        String expectedQuestion = "population of " + everestUri.toString();
-
-        List<NamedEntity> entities0 = new LinkedList<>();
-        entities0.add(new NamedEntity(everestUri, "population of ".length(), "france", threshold + 0.001f));
-        String computedQuestion = myApp.computeQuestionStringWithReplacedResources(question, entities0, threshold);
-
-        // check correct transformation of the given question
-        assertEquals(expectedQuestion, computedQuestion, //
-                "From '" + question + "' it was expected '" + expectedQuestion //
-                        + "' but computed '" + computedQuestion + "'");
-
-        // TODO: receive a ASK query answer
-        QAnswerResult result1 = testWebService(myApp, computedQuestion, lang, kb, user);
-
-        assertEquals(result0.getValues().get(0).get("query"), result1.getValues().get(0).get("query"), "Results are not equal");
+        // check if the query candidates contain at least one ASK type query
+        QAnswerResult result = testWebService(myApp, question, lang, kb, user);
+        for (QAnswerQueryCandidate queryCandidate : result.getQueryCandidates()) {
+            Query query = QueryFactory.create(queryCandidate.getQueryString());
+            if (query.isAskType()) {
+                assert(true);
+                return;
+            }
+        }
+        assert(false);
     }
-
-    /**
-     * check if string is computed
-     *
-     * @throws URISyntaxException
-     * @throws ParseException
-     * @throws NoLiteralFieldFoundException
-     * @throws MalformedURLException
-     */
-    @Test
-    @EnabledIf(
-            expression = "#{environment['test.live.endpoints'] == 'true'}", //
-            loadContext = true)
-    void testWebServiceWhatIsTheNicknameOfRomeResultString() throws URISyntaxException, ParseException, MalformedURLException {
-
-        float threshold = 0.4f;
-        String lang = "en";
-        String kb = "wikidata";
-        String user = "open";
-
-        QAnswerQueryBuilderAndSparqlResultFetcher myApp = new QAnswerQueryBuilderAndSparqlResultFetcher(threshold, lang, kb, user,
-                this.realEndpoint, applicationName, restTemplate);
-        String question = "what is the nickname of Rome";
-        QAnswerResult result0 = testWebService(myApp, question, lang, kb, user);
-
-        assertTrue(result0.getValues().size() > 2);
-    }
-
 
     private QAnswerResult testWebService(QAnswerQueryBuilderAndSparqlResultFetcher myApp, String question, String lang, String kb, String user)
             throws URISyntaxException, MalformedURLException {
         QAnswerResult result = myApp.requestQAnswerWebService(realEndpoint, question, lang, kb, user);
         logger.debug("testWebService result: {}", result);
-        assertTrue(result.getValues().size() > 0);
+        assertTrue(result.getQueryCandidates().size() > 0);
         return result;
     }
 

--- a/qanary-component-QB-QAnswer/src/test/java/eu/wdaqua/qanary/component/qanswer/qb/QanaryCustomControllerTest.java
+++ b/qanary-component-QB-QAnswer/src/test/java/eu/wdaqua/qanary/component/qanswer/qb/QanaryCustomControllerTest.java
@@ -1,7 +1,16 @@
 package eu.wdaqua.qanary.component.qanswer.qb;
 
-import eu.wdaqua.qanary.component.qanswer.qb.messages.QAnswerRequest;
-import eu.wdaqua.qanary.component.qanswer.qb.messages.QAnswerResult;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import javax.inject.Inject;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,15 +29,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 
-import javax.inject.Inject;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import eu.wdaqua.qanary.component.qanswer.qb.messages.QAnswerRequest;
+import eu.wdaqua.qanary.component.qanswer.qb.messages.QAnswerResult;
 
 /**
  * test the custom endpoint of this component
@@ -77,8 +79,8 @@ class QanaryCustomControllerTest {
         String user = "open";
 
         QAnswerResult result0 = customController.requestQAnswerWebService(this.realEndpoint, question, lang, kb, user);
-        assertTrue(result0.getValues().size() > 0, "the number of fetched results should be > 0, but  was " + result0.getValues().size());
-        assertTrue(result0.getValues().size() <= 60, "the number of fetched results should be <= 60, but  was " + result0.getValues().size());
+        assertTrue(result0.getQueryCandidates().size() > 0, "the number of fetched results should be > 0, but  was " + result0.getQueryCandidates().size());
+        assertTrue(result0.getQueryCandidates().size() <= 60, "the number of fetched results should be <= 60, but  was " + result0.getQueryCandidates().size());
 
         QAnswerRequest requestMessage = new QAnswerRequest(question, lang, kb, user);
 
@@ -94,14 +96,13 @@ class QanaryCustomControllerTest {
                     .andExpect(MockMvcResultMatchers.jsonPath("$.result.knowledgebaseId").exists()) //
                     .andExpect(MockMvcResultMatchers.jsonPath("$.result.language").exists()) //
                     .andExpect(MockMvcResultMatchers.jsonPath("$.result.question").exists()) //
-                    .andExpect(MockMvcResultMatchers.jsonPath("$.result.values").exists()) //
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.result.queryCandidates").exists()) //
                     .andReturn();
 
         } catch (Exception e) {
             fail(e.getMessage());
             return;
         }
-
 
         // TODO: check the content of the response fields being equal to the previous result
         try {
@@ -114,14 +115,12 @@ class QanaryCustomControllerTest {
                     .andExpect(MockMvcResultMatchers.jsonPath("$.knowledgebaseId").exists()) //
                     .andExpect(MockMvcResultMatchers.jsonPath("$.language").exists()) //
                     .andExpect(MockMvcResultMatchers.jsonPath("$.question").exists()) //
-                    .andExpect(MockMvcResultMatchers.jsonPath("$.values").exists()) //
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.queryCandidates").exists()) //
                     .andReturn();
         } catch (Exception e) {
             fail(e.getMessage());
             return;
         }
-
-
     }
 
 }

--- a/qanary-component-QBE-QAnswer/README.md
+++ b/qanary-component-QBE-QAnswer/README.md
@@ -9,7 +9,6 @@ Consequently, your request to the QAnswer API might be more precise.
 ## Background
 
 [QAnswer](https://www.qanswer.eu/) is an API capable of retrieving data from different knowledge graphs.
-An example is available at [https://qanswer-frontend.univ-st-etienne.fr/](https://qanswer-frontend.univ-st-etienne.fr/).
 
 ## Input specification
 
@@ -144,7 +143,7 @@ The following attributes should be changed if required (typically in the file `a
 
 ```ini
 # define the API endpoint of the QAnswer API
-qanswer.endpoint.url=http://qanswer-core1.univ-st-etienne.fr/api/gerbil
+qanswer.endpoint.url=https://qanswer-core1.univ-st-etienne.fr/api/gerbil
 
 # define the minimum required confidence (property: `qa:score`) for named entities (otherwise they are ignored)
 qanswer.qbe.namedentities.threshold=0.5

--- a/qanary-component-QBE-QAnswer/pom.xml
+++ b/qanary-component-QBE-QAnswer/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eu.wdaqua.qanary.component</groupId>
 	<artifactId>qanary-component-QBE-QAnswer</artifactId>
-	<version>3.2.4</version>
+	<version>3.3.0</version>
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -14,7 +14,7 @@
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<properties>
-		<java.version>11</java.version>
+		<java.version>17</java.version>
 		<qanary.version>[3.7.1,4.0.0)</qanary.version>
 		<spring-boot-admin.version>2.7.10</spring-boot-admin.version>
 		<docker.image.prefix>qanary</docker.image.prefix>

--- a/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/QAnswerQueryBuilderAndExecutorController.java
+++ b/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/QAnswerQueryBuilderAndExecutorController.java
@@ -52,7 +52,7 @@ public class QAnswerQueryBuilderAndExecutorController {
      *
      * <pre>
      * {
-     * "qanswerEndpointUrl": "http://qanswer-core1.univ-st-etienne.fr/api/gerbil",
+     * "qanswerEndpointUrl": "https://qanswer-core1.univ-st-etienne.fr/api/gerbil",
      * "questionString": "What is the capital of Germany?",
      * "lang": "en",
      * "knowledgeBaseId": "wikidata"

--- a/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/messages/QAnswerRequest.java
+++ b/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/messages/QAnswerRequest.java
@@ -6,7 +6,7 @@ import javax.validation.constraints.NotBlank;
 import java.net.URI;
 
 public class QAnswerRequest {
-    @Schema(description = "Endpoint URL of QAnswer API (default is already available)", example = "http://qanswer-core1.univ-st-etienne.fr/api/gerbil", required = false)
+    @Schema(description = "Endpoint URL of QAnswer API (default is already available)", example = "https://qanswer-core1.univ-st-etienne.fr/api/gerbil", required = false)
     private URI qanswerEndpointUrl;
     @NotBlank
     @Schema(description = "Question for that the results will be fetched from the QAnswer API", example = "What is the capital of Germany?", required = true)

--- a/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/messages/QAnswerResult.java
+++ b/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/messages/QAnswerResult.java
@@ -22,7 +22,6 @@ public class QAnswerResult {
     public final URI BOOLEANTYPEURI;
     @Hidden
     public final URI STRINGTYPEURI;
-    private com.google.gson.JsonParser jsonParser;
     private URI endpoint;
     private String knowledgebaseId;
     private String user;
@@ -36,9 +35,7 @@ public class QAnswerResult {
     private String jsonString;
 
     public QAnswerResult(JSONObject json, String question, URI endpoint, String language, String knowledgebaseId, String user) throws URISyntaxException, NoLiteralFieldFoundException {
-        jsonParser = new JsonParser();
-        JsonArray parsedJsonArray = jsonParser.parse(json.toJSONString()).getAsJsonObject().getAsJsonArray("questions")
-                .getAsJsonArray();
+        JsonArray parsedJsonArray = JsonParser.parseString(json.toJSONString()).getAsJsonObject().getAsJsonArray("questions").getAsJsonArray();
 
         this.jsonString = json.toString();
         this.question = question;
@@ -120,7 +117,7 @@ public class QAnswerResult {
         JsonObject questionData = answers.get(0).getAsJsonObject().get("question").getAsJsonObject();
         logger.debug("responseQuestion: {}", questionData);
 
-        JsonObject concreteAnswers = jsonParser.parse(questionData.get("answers").getAsString()).getAsJsonObject();
+        JsonObject concreteAnswers = JsonParser.parseString(questionData.get("answers").getAsString()).getAsJsonObject();
         logger.debug("responseQuestion->answers: {}", concreteAnswers.toString());
 
         JsonObject results = concreteAnswers.get("results").getAsJsonObject();
@@ -184,7 +181,7 @@ public class QAnswerResult {
         JsonObject questionData = answers.get(0).getAsJsonObject().get("question").getAsJsonObject();
         logger.debug("responseQuestion: {}", questionData);
 
-        JsonObject concreteAnswers = jsonParser.parse(questionData.get("answers").getAsString()).getAsJsonObject();
+        JsonObject concreteAnswers = JsonParser.parseString(questionData.get("answers").getAsString()).getAsJsonObject();
         logger.debug("responseQuestion->answers: {}", concreteAnswers.toString());
 
         JsonObject results = concreteAnswers.get("results").getAsJsonObject();
@@ -238,11 +235,10 @@ public class QAnswerResult {
         JsonObject questionData = answers.get(0).getAsJsonObject().get("question").getAsJsonObject();
         logger.debug("questionData: {}", questionData);
 
-        com.google.gson.JsonParser jsonParser = new JsonParser();
-        JsonObject parsedAnswer = jsonParser.parse(questionData.toString()).getAsJsonObject();
+        JsonObject parsedAnswer = JsonParser.parseString(questionData.toString()).getAsJsonObject();
         logger.debug("parsedAnswer: {}", parsedAnswer);
 
-        JsonObject concreteAnswer = jsonParser.parse(parsedAnswer.get("answers").getAsString()).getAsJsonObject();
+        JsonObject concreteAnswer = JsonParser.parseString(parsedAnswer.get("answers").getAsString()).getAsJsonObject();
         logger.debug("concreteAnswer: {}", concreteAnswer);
 
         boolean result = concreteAnswer.get("boolean").getAsBoolean();


### PR DESCRIPTION
**QB QAnswer Wrapper** (3.1.6 -> 4.0.0)
* update QAnswer API url for query candidates
* upgrade Java to version 17
* adjust class `QAnswerResult` to better reflect the focus on query candidates
* adjust unit tests to better reflect the focus on query candidates
* separate methods for building SPARQL INSERT queries, to make use of `QanaryTripleStoreConnector.insertAnnotationOfAnswerSPARQL()`
* refactor JSON parsing for `QAnswerResult`

**QBE QAnswer Wrapper** (3.2.4 -> 3.3.0)
* update QAnswer API url for full question answering
* upgrade Java to version 17
* refactor JSON parsing for `QAnswerResult`