### PR TITLE
Split insert queries python components

### DIFF
--- a/qanary-component-MT-Python-HelsinkiNLP/component/__init__.py
+++ b/qanary-component-MT-Python-HelsinkiNLP/component/__init__.py
@@ -1,7 +1,7 @@
 from component.mt_helsinki_nlp import mt_helsinki_nlp_bp
 from flask import Flask
 
-version = "0.1.1"
+version = "0.1.2"
 
 # default config file (use -c parameter on command line specify a custom config file)
 configfile = "app.conf"

--- a/qanary-component-MT-Python-HelsinkiNLP/component/mt_helsinki_nlp.py
+++ b/qanary-component-MT-Python-HelsinkiNLP/component/mt_helsinki_nlp.py
@@ -57,7 +57,7 @@ def qanary_service():
     result = tokenizers[lang].batch_decode(translation, skip_special_tokens=True)[0]
 
     # building SPARQL query TODO: verify this annotation AnnotationOfQuestionTranslation ??
-    SPARQLquery = """
+    SPARQLqueryAnnotationOfQuestionTranslation = """
         PREFIX qa: <http://www.wdaqua.eu/qa#>
         PREFIX oa: <http://www.w3.org/ns/openannotation/core/>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -70,6 +70,27 @@ def qanary_service():
                 oa:annotatedBy <urn:qanary:{app_name}> ;
                 oa:annotatedAt ?time .
 
+            }}
+        }}
+        WHERE {{
+            BIND (IRI(str(RAND())) AS ?a) .
+            BIND (now() as ?time)
+        }}
+    """.format(
+        uuid=triplestore_ingraph,
+        qanary_question_uri=question_uri,
+        translation_result=result.replace("\"", "\\\""), #keep quotation marks that are part of the translation
+        target_lang=TARGET_LANG,
+        app_name=SERVICE_NAME_COMPONENT
+    )
+
+    SPARQLqueryAnnotationOfQuestionLanguage = """
+        PREFIX qa: <http://www.wdaqua.eu/qa#>
+        PREFIX oa: <http://www.w3.org/ns/openannotation/core/>
+        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+        INSERT {{
+        GRAPH <{uuid}> {{
             ?b a qa:AnnotationOfQuestionLanguage ;
                 oa:hasTarget <{qanary_question_uri}> ;
                 oa:hasBody "{src_lang}"^^xsd:string ;
@@ -78,22 +99,21 @@ def qanary_service():
             }}
         }}
         WHERE {{
-            BIND (IRI(str(RAND())) AS ?a) .
             BIND (IRI(str(RAND())) AS ?b) .
             BIND (now() as ?time)
         }}
     """.format(
         uuid=triplestore_ingraph,
         qanary_question_uri=question_uri,
-        translation_result=result.replace("\"", "\\\""), #keep quotation marks that are part of the translation
         src_lang=lang,
-        target_lang=TARGET_LANG,
         app_name=SERVICE_NAME_COMPONENT
     )
 
-    logging.info(f'SPARQL: {SPARQLquery}')
+    logging.info(f'SPARQL: {SPARQLqueryAnnotationOfQuestionTranslation}')
+    logging.info(f'SPARQL: {SPARQLqueryAnnotationOfQuestionLanguage}')
     # inserting new data to the triplestore
-    insert_into_triplestore(triplestore_endpoint, SPARQLquery)
+    insert_into_triplestore(triplestore_endpoint, SPARQLqueryAnnotationOfQuestionTranslation)
+    insert_into_triplestore(triplestore_endpoint, SPARQLqueryAnnotationOfQuestionLanguage)
 
     return jsonify(request.get_json())
 

--- a/qanary-component-MT-Python-LibreTranslate/component/__init__.py
+++ b/qanary-component-MT-Python-LibreTranslate/component/__init__.py
@@ -3,7 +3,7 @@ from component.mt_libretranslate import check_connection
 from component.mt_libretranslate import get_languages
 from flask import Flask
 
-version = "0.1.1"
+version = "0.1.2"
 
 # default config file
 configfile = "app.conf"

--- a/qanary-component-MT-Python-LibreTranslate/component/mt_libretranslate.py
+++ b/qanary-component-MT-Python-LibreTranslate/component/mt_libretranslate.py
@@ -43,17 +43,40 @@ def qanary_service():
     result, _ = translate_input(text, lang)
 
     # building SPARQL query TODO: verify this annotation AnnotationOfQuestionTranslation ??
-    SPARQLquery = """
+    SPARQLqueryAnnotationOfQuestionTranslation = """
         PREFIX qa: <http://www.wdaqua.eu/qa#>
         PREFIX oa: <http://www.w3.org/ns/openannotation/core/>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
         INSERT {{
         GRAPH <{uuid}> {{
             ?a a qa:AnnotationOfQuestionTranslation ;
-                oa:hasTarget <{qanary_question_uri}> ; 
-                oa:hasBody "{translation_result}"@en ;
+                oa:hasTarget <{qanary_question_uri}> ;
+                oa:hasBody "{translation_result}"@{target_lang} ;
                 oa:annotatedBy <urn:qanary:{app_name}> ;
                 oa:annotatedAt ?time .
+
+            }}
+        }}
+        WHERE {{
+            BIND (IRI(str(RAND())) AS ?a) .
+            BIND (now() as ?time)
+        }}
+    """.format(
+        uuid=triplestore_ingraph,
+        qanary_question_uri=question_uri,
+        translation_result=result.replace("\"", "\\\""), #keep quotation marks that are part of the translation
+        target_lang=TARGET_LANG,
+        app_name=SERVICE_NAME_COMPONENT
+    )
+
+    SPARQLqueryAnnotationOfQuestionLanguage = """
+        PREFIX qa: <http://www.wdaqua.eu/qa#>
+        PREFIX oa: <http://www.w3.org/ns/openannotation/core/>
+        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+        INSERT {{
+        GRAPH <{uuid}> {{
             ?b a qa:AnnotationOfQuestionLanguage ;
                 oa:hasTarget <{qanary_question_uri}> ;
                 oa:hasBody "{src_lang}"^^xsd:string ;
@@ -62,21 +85,21 @@ def qanary_service():
             }}
         }}
         WHERE {{
-            BIND (IRI(str(RAND())) AS ?a) .
             BIND (IRI(str(RAND())) AS ?b) .
-            BIND (now() as ?time) 
+            BIND (now() as ?time)
         }}
     """.format(
         uuid=triplestore_ingraph,
         qanary_question_uri=question_uri,
-        translation_result=result,
         src_lang=lang,
         app_name=SERVICE_NAME_COMPONENT
     )
-    
-    logging.info(f'SPARQL: {SPARQLquery}')
+
+    logging.info(f'SPARQL: {SPARQLqueryAnnotationOfQuestionTranslation}')
+    logging.info(f'SPARQL: {SPARQLqueryAnnotationOfQuestionLanguage}')
     # inserting new data to the triplestore
-    insert_into_triplestore(triplestore_endpoint, SPARQLquery)
+    insert_into_triplestore(triplestore_endpoint, SPARQLqueryAnnotationOfQuestionTranslation)
+    insert_into_triplestore(triplestore_endpoint, SPARQLqueryAnnotationOfQuestionLanguage)
 
     return jsonify(request.get_json())
 

--- a/qanary-component-MT-Python-MBart/component/__init__.py
+++ b/qanary-component-MT-Python-MBart/component/__init__.py
@@ -1,7 +1,7 @@
 from component.mt_mbart_nlp import mt_mbart_nlp_bp
 from flask import Flask 
 
-version = "0.1.1"
+version = "0.1.2"
 
 # default config file
 configfile = "app.conf"

--- a/qanary-component-MT-Python-MBart/component/mt_mbart_nlp.py
+++ b/qanary-component-MT-Python-MBart/component/mt_mbart_nlp.py
@@ -72,7 +72,7 @@ def qanary_service():
 
 
     # building SPARQL query TODO: verify this annotation AnnotationOfQuestionTranslation ??
-    SPARQLquery = """
+    SPARQLqueryAnnotationOfQuestionTranslation = """
         PREFIX qa: <http://www.wdaqua.eu/qa#>
         PREFIX oa: <http://www.w3.org/ns/openannotation/core/>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -85,6 +85,27 @@ def qanary_service():
                 oa:annotatedBy <urn:qanary:{app_name}> ;
                 oa:annotatedAt ?time .
 
+            }}
+        }}
+        WHERE {{
+            BIND (IRI(str(RAND())) AS ?a) .
+            BIND (now() as ?time)
+        }}
+    """.format(
+        uuid=triplestore_ingraph,
+        qanary_question_uri=question_uri,
+        translation_result=result.replace("\"", "\\\""), #keep quotation marks that are part of the translation
+        target_lang=TARGET_LANG,
+        app_name=SERVICE_NAME_COMPONENT
+    )
+
+    SPARQLqueryAnnotationOfQuestionLanguage = """
+        PREFIX qa: <http://www.wdaqua.eu/qa#>
+        PREFIX oa: <http://www.w3.org/ns/openannotation/core/>
+        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+        INSERT {{
+        GRAPH <{uuid}> {{
             ?b a qa:AnnotationOfQuestionLanguage ;
                 oa:hasTarget <{qanary_question_uri}> ;
                 oa:hasBody "{src_lang}"^^xsd:string ;
@@ -93,22 +114,21 @@ def qanary_service():
             }}
         }}
         WHERE {{
-            BIND (IRI(str(RAND())) AS ?a) .
             BIND (IRI(str(RAND())) AS ?b) .
             BIND (now() as ?time)
         }}
     """.format(
         uuid=triplestore_ingraph,
         qanary_question_uri=question_uri,
-        translation_result=result.replace("\"", "\\\""), #keep quotation marks that are part of the translation
         src_lang=lang,
-        target_lang=target_lang,
         app_name=SERVICE_NAME_COMPONENT
     )
 
-    logging.info(f'SPARQL: {SPARQLquery}')
+    logging.info(f'SPARQL: {SPARQLqueryAnnotationOfQuestionTranslation}')
+    logging.info(f'SPARQL: {SPARQLqueryAnnotationOfQuestionLanguage}')
     # inserting new data to the triplestore
-    insert_into_triplestore(triplestore_endpoint, SPARQLquery)
+    insert_into_triplestore(triplestore_endpoint, SPARQLqueryAnnotationOfQuestionTranslation)
+    insert_into_triplestore(triplestore_endpoint, SPARQLqueryAnnotationOfQuestionLanguage)
 
     return jsonify(request.get_json())
 

--- a/qanary-component-MT-Python-NLLB/component/__init__.py
+++ b/qanary-component-MT-Python-NLLB/component/__init__.py
@@ -1,7 +1,7 @@
 from component.mt_nllb import mt_nllb_bp
 from flask import Flask
 
-version = "0.1.1"
+version = "0.1.2"
 
 # default config file
 configfile = "app.conf"

--- a/qanary-component-MT-Python-NLLB/component/mt_nllb.py
+++ b/qanary-component-MT-Python-NLLB/component/mt_nllb.py
@@ -70,43 +70,63 @@ def qanary_service():
 
 
     # building SPARQL query TODO: verify this annotation AnnotationOfQuestionTranslation ??
-    SPARQLquery = """
-        PREFIX qa: <http://www.wdaqua.eu/qa#>
-        PREFIX oa: <http://www.w3.org/ns/openannotation/core/>
-        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+        SPARQLqueryAnnotationOfQuestionTranslation = """
+            PREFIX qa: <http://www.wdaqua.eu/qa#>
+            PREFIX oa: <http://www.w3.org/ns/openannotation/core/>
+            PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-        INSERT {{
-        GRAPH <{uuid}> {{
-            ?a a qa:AnnotationOfQuestionTranslation ;
-                oa:hasTarget <{qanary_question_uri}> ;
-                oa:hasBody "{translation_result}"@{target_lang} ;
-                oa:annotatedBy <urn:qanary:{app_name}> ;
-                oa:annotatedAt ?time .
+            INSERT {{
+            GRAPH <{uuid}> {{
+                ?a a qa:AnnotationOfQuestionTranslation ;
+                    oa:hasTarget <{qanary_question_uri}> ;
+                    oa:hasBody "{translation_result}"@{target_lang} ;
+                    oa:annotatedBy <urn:qanary:{app_name}> ;
+                    oa:annotatedAt ?time .
 
-            ?b a qa:AnnotationOfQuestionLanguage ;
-                oa:hasTarget <{qanary_question_uri}> ;
-                oa:hasBody "{src_lang}"^^xsd:string ;
-                oa:annotatedBy <urn:qanary:{app_name}> ;
-                oa:annotatedAt ?time .
+                }}
             }}
-        }}
-        WHERE {{
-            BIND (IRI(str(RAND())) AS ?a) .
-            BIND (IRI(str(RAND())) AS ?b) .
-            BIND (now() as ?time)
-        }}
-    """.format(
-        uuid=triplestore_ingraph,
-        qanary_question_uri=question_uri,
-        translation_result=result.replace("\"", "\\\""), #keep quotation marks that are part of the translation
-        src_lang=lang,
-        target_lang=target_lang,
-        app_name=SERVICE_NAME_COMPONENT
-    )
+            WHERE {{
+                BIND (IRI(str(RAND())) AS ?a) .
+                BIND (now() as ?time)
+            }}
+        """.format(
+            uuid=triplestore_ingraph,
+            qanary_question_uri=question_uri,
+            translation_result=result.replace("\"", "\\\""), #keep quotation marks that are part of the translation
+            target_lang=TARGET_LANG,
+            app_name=SERVICE_NAME_COMPONENT
+        )
 
-    logging.info(f'SPARQL: {SPARQLquery}')
-    # inserting new data to the triplestore
-    insert_into_triplestore(triplestore_endpoint, SPARQLquery)
+        SPARQLqueryAnnotationOfQuestionLanguage = """
+            PREFIX qa: <http://www.wdaqua.eu/qa#>
+            PREFIX oa: <http://www.w3.org/ns/openannotation/core/>
+            PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+            INSERT {{
+            GRAPH <{uuid}> {{
+                ?b a qa:AnnotationOfQuestionLanguage ;
+                    oa:hasTarget <{qanary_question_uri}> ;
+                    oa:hasBody "{src_lang}"^^xsd:string ;
+                    oa:annotatedBy <urn:qanary:{app_name}> ;
+                    oa:annotatedAt ?time .
+                }}
+            }}
+            WHERE {{
+                BIND (IRI(str(RAND())) AS ?b) .
+                BIND (now() as ?time)
+            }}
+        """.format(
+            uuid=triplestore_ingraph,
+            qanary_question_uri=question_uri,
+            src_lang=lang,
+            app_name=SERVICE_NAME_COMPONENT
+        )
+
+        logging.info(f'SPARQL: {SPARQLqueryAnnotationOfQuestionTranslation}')
+        logging.info(f'SPARQL: {SPARQLqueryAnnotationOfQuestionLanguage}')
+        # inserting new data to the triplestore
+        insert_into_triplestore(triplestore_endpoint, SPARQLqueryAnnotationOfQuestionTranslation)
+        insert_into_triplestore(triplestore_endpoint, SPARQLqueryAnnotationOfQuestionLanguage)
 
     return jsonify(request.get_json())
 


### PR DESCRIPTION
Adjusted components [#379](https://github.com/orgs/WSE-research/projects/3/views/14?pane=issue&itemId=43908158) :
- https://github.com/WDAqua/Qanary-question-answering-components/tree/master/qanary-component-MT-Python-HelsinkiNLP
- https://github.com/WDAqua/Qanary-question-answering-components/tree/master/qanary-component-MT-Python-LibreTranslate
- https://github.com/WDAqua/Qanary-question-answering-components/tree/master/qanary-component-MT-Python-MBart
- https://github.com/WDAqua/Qanary-question-answering-components/tree/master/qanary-component-MT-Python-NLLB

Split the Insert-Queries, so that the RAND()-binding is split too.