### PR TITLE
Extract QAnswer queries to files 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,5 +148,6 @@ dmypy.json
 
 .factorypath
 
-# LOCAL APPLEICATION PROPERTIES
+# LOCAL FILES
 application-local.properties
+.run_tests

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,8 @@
         <module>qanary-component-KG2KG-TranslateAnnotationsOfInstance</module>
                         
         <module>qanary-component-QB-DateOfDeathDBpedia</module>
+
+        <module>qanary-component-QB-DeepPavlovWrapper</module>
                     
       </modules>
               

--- a/qanary-component-QB-BirthDataWikidata/pom.xml
+++ b/qanary-component-QB-BirthDataWikidata/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eu.wdaqua.qanary.component</groupId>
 	<artifactId>qanary-component-QB-BirthDataWikidata</artifactId>
-	<version>3.4.0</version>
+	<version>3.4.1</version>
 	<parent>
 		<groupId>eu.wdaqua.qanary</groupId>
 		<artifactId>qa.qanarycomponent-parent</artifactId>

--- a/qanary-component-QB-BirthDataWikidata/src/main/java/eu/wdaqua/component/qb/birthdata/wikidata/BirthDataQueryBuilder.java
+++ b/qanary-component-QB-BirthDataWikidata/src/main/java/eu/wdaqua/component/qb/birthdata/wikidata/BirthDataQueryBuilder.java
@@ -243,6 +243,7 @@ public class BirthDataQueryBuilder extends QanaryComponent {
 																												// confidence
 																												// is
 																												// expressed
+				bindings.add("index", ResourceFactory.createTypedLiteral(Integer.toString(i), XSDDatatype.XSDint));
 				bindings.add("application", ResourceFactory.createResource("urn:qanary:" + this.applicationName));
 
 				// get the template of the INSERT query

--- a/qanary-component-QB-DateOfDeathDBpedia/pom.xml
+++ b/qanary-component-QB-DateOfDeathDBpedia/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.wdaqua.qanary.component</groupId>
     <artifactId>qanary-component-QB-DateOfDeathDBpedia</artifactId>
-    <version>0.1.3</version>
+    <version>0.1.4</version>
     <parent> 
         <groupId>eu.wdaqua.qanary</groupId> 
         <artifactId>qa.qanarycomponent-parent</artifactId>

--- a/qanary-component-QB-DateOfDeathDBpedia/src/main/java/eu/wdaqua/qanary/component/dateofdeathrealpersons/qb/QueryBuilderDateOfDeathDBpedia.java
+++ b/qanary-component-QB-DateOfDeathDBpedia/src/main/java/eu/wdaqua/qanary/component/dateofdeathrealpersons/qb/QueryBuilderDateOfDeathDBpedia.java
@@ -49,7 +49,6 @@ public class QueryBuilderDateOfDeathDBpedia extends QanaryComponent {
     private static final String QUERY_FILE_DBPEDIA_QUERY = "/queries/dbpedia_query.rq";
 
     // used from the Qanary commons queries, query to create a new annotation and store the computed query
-    private static final String QUERY_FILE_STORE_COMPUTED_ANNOTATIONS = "/queries/insert_one_AnnotationOfAnswerSPARQL.rq";
     private static final Logger logger = LoggerFactory.getLogger(QueryBuilderDateOfDeathDBpedia.class);
     private final String SUPPORTED_PREFIX = "What is the date of death of ";
     private final String applicationName;
@@ -60,7 +59,6 @@ public class QueryBuilderDateOfDeathDBpedia extends QanaryComponent {
         // here if the files are available and do contain content // do files exist?
         QanaryTripleStoreConnector.guardNonEmptyFileFromResources(QUERY_FILE_FETCH_REQUIRED_ANNOTATIONS);
         QanaryTripleStoreConnector.guardNonEmptyFileFromResources(QUERY_FILE_DBPEDIA_QUERY);
-        QanaryTripleStoreConnector.guardNonEmptyFileFromResources(QUERY_FILE_STORE_COMPUTED_ANNOTATIONS);
     }
 
     /**
@@ -155,9 +153,9 @@ public class QueryBuilderDateOfDeathDBpedia extends QanaryComponent {
      */
     public List<String> createQueries(QanaryQuestion qanaryQuestion, List<String> queries) throws Exception {
         List<String> createdQueries = new ArrayList<>();
-        for (String entity : queries
-        ) {
-            createdQueries.add(getInsertQuery(qanaryQuestion, entity));
+
+        for (int i = 0; i > queries.size(); i++) {
+            createdQueries.add(getInsertQuery(qanaryQuestion, queries.get(i), i));
         }
         return createdQueries;
     }
@@ -195,7 +193,7 @@ public class QueryBuilderDateOfDeathDBpedia extends QanaryComponent {
     }
 
     // binds query variables with concrete values and returns the Insert-query
-    public String getInsertQuery(QanaryQuestion<String> myQanaryQuestion, String createdDbpediaQuery)
+    public String getInsertQuery(QanaryQuestion<String> myQanaryQuestion, String createdDbpediaQuery, int index)
             throws SparqlQueryFailed, URISyntaxException, QanaryExceptionNoOrMultipleQuestions, IOException {
 
         QuerySolutionMap bindingsForInsert = new QuerySolutionMap();
@@ -204,8 +202,9 @@ public class QueryBuilderDateOfDeathDBpedia extends QanaryComponent {
         bindingsForInsert.add("application", ResourceFactory.createResource("urn:qanary:" + this.applicationName));
         bindingsForInsert.add("selectQueryThatShouldComputeTheAnswer", ResourceFactory.createTypedLiteral(createdDbpediaQuery, XSDDatatype.XSDdate));
         bindingsForInsert.add("score", ResourceFactory.createTypedLiteral("1.0", XSDDatatype.XSDfloat));
+        bindingsForInsert.add("index", ResourceFactory.createTypedLiteral(Integer.toString(index), XSDDatatype.XSDint));
 
-        return QanaryTripleStoreConnector.readFileFromResourcesWithMap(QUERY_FILE_STORE_COMPUTED_ANNOTATIONS, bindingsForInsert);
+        return QanaryTripleStoreConnector.insertAnnotationOfAnswerSPARQL(bindingsForInsert);
     }
 
 }

--- a/qanary-component-QB-DeepPavlovWrapper/pom.xml
+++ b/qanary-component-QB-DeepPavlovWrapper/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eu.wdaqua.qanary.component</groupId>
 	<artifactId>qanary-component-QB-DeepPavlovWrapper</artifactId>
-	<version>0.1.1</version>
+	<version>0.2.0</version>
 
 	<parent>
 		<groupId>eu.wdaqua.qanary</groupId>

--- a/qanary-component-QB-DeepPavlovWrapper/src/main/java/eu/wdaqua/qanary/component/deeppavlovwrapper/qb/DeepPavlovWrapper.java
+++ b/qanary-component-QB-DeepPavlovWrapper/src/main/java/eu/wdaqua/qanary/component/deeppavlovwrapper/qb/DeepPavlovWrapper.java
@@ -159,7 +159,8 @@ public class DeepPavlovWrapper extends QanaryComponent {
         // STEP 3: store computed knowledge about the given question into the Qanary triplestore 
         // (the global process memory)
         // --------------------------------------------------------------------
-        String sparql = getSparqlInsertQuery(myQanaryQuestion, result);
+        int index = 0; // only one query expected
+        String sparql = getSparqlInsertQuery(myQanaryQuestion, result, index);
         myQanaryUtils.getQanaryTripleStoreConnector().update(sparql);
       }
     } catch (Exception e) {
@@ -239,7 +240,7 @@ public class DeepPavlovWrapper extends QanaryComponent {
      * @throws SparqlQueryFailed
      * @throws IOException
      */
-    protected String getSparqlInsertQuery(QanaryQuestion<String> myQanaryQuestion, DeepPavlovResult result) throws QanaryExceptionNoOrMultipleQuestions, URISyntaxException, SparqlQueryFailed, IOException {
+    protected String getSparqlInsertQuery(QanaryQuestion<String> myQanaryQuestion, DeepPavlovResult result, int index) throws QanaryExceptionNoOrMultipleQuestions, URISyntaxException, SparqlQueryFailed, IOException {
 
       String query = prepareResultQueryForSparqlInsert(result.getSparql());
 
@@ -250,7 +251,7 @@ public class DeepPavlovWrapper extends QanaryComponent {
       bindings.add("targetQuestion", ResourceFactory.createResource(myQanaryQuestion.getUri().toASCIIString()));
       bindings.add("selectQueryThatShouldComputeTheAnswer", ResourceFactory.createStringLiteral(query));
       bindings.add("confidence", ResourceFactory.createTypedLiteral(result.getConfidence()));
-      bindings.add("index", ResourceFactory.createTypedLiteral(0)); // TODO: currently, only one SPARQL is annotated, so index is always 0
+      bindings.add("index", ResourceFactory.createTypedLiteral(index)); 
       bindings.add("application", ResourceFactory.createResource("urn:qanary:" + this.applicationName));
 
       // get the template of the INSERT query

--- a/qanary-component-QB-DeepPavlovWrapper/src/main/java/eu/wdaqua/qanary/component/deeppavlovwrapper/qb/DeepPavlovWrapper.java
+++ b/qanary-component-QB-DeepPavlovWrapper/src/main/java/eu/wdaqua/qanary/component/deeppavlovwrapper/qb/DeepPavlovWrapper.java
@@ -250,6 +250,7 @@ public class DeepPavlovWrapper extends QanaryComponent {
       bindings.add("targetQuestion", ResourceFactory.createResource(myQanaryQuestion.getUri().toASCIIString()));
       bindings.add("selectQueryThatShouldComputeTheAnswer", ResourceFactory.createStringLiteral(query));
       bindings.add("confidence", ResourceFactory.createTypedLiteral(result.getConfidence()));
+      bindings.add("index", ResourceFactory.createTypedLiteral(0)); // TODO: currently, only one SPARQL is annotated, so index is always 0
       bindings.add("application", ResourceFactory.createResource("urn:qanary:" + this.applicationName));
 
       // get the template of the INSERT query

--- a/qanary-component-QB-GAnswerWrapper/pom.xml
+++ b/qanary-component-QB-GAnswerWrapper/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.wdaqua.qanary.component</groupId>
     <artifactId>qanary-component-QB-GAnswerWrapper</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3</version>
 
     <parent>
       <groupId>eu.wdaqua.qanary</groupId>

--- a/qanary-component-QB-GAnswerWrapper/src/main/java/eu/wdaqua/qanary/component/ganswerwrapper/qb/GAnswerQueryBuilder.java
+++ b/qanary-component-QB-GAnswerWrapper/src/main/java/eu/wdaqua/qanary/component/ganswerwrapper/qb/GAnswerQueryBuilder.java
@@ -138,7 +138,8 @@ import java.util.List;
         }
 
         // STEP 3: add information to Qanary triplestore
-        String sparql = getSparqlInsertQuery(myQanaryQuestion, result);
+        int index = 0; // only one query expected
+        String sparql = getSparqlInsertQuery(myQanaryQuestion, result, index);
         myQanaryUtils.getQanaryTripleStoreConnector().update(sparql);
 
         return myQanaryMessage;
@@ -197,7 +198,7 @@ import java.util.List;
      * @throws SparqlQueryFailed
      * @throws IOException
      */
-    protected String getSparqlInsertQuery(QanaryQuestion<String> myQanaryQuestion, GAnswerResult result) throws QanaryExceptionNoOrMultipleQuestions, URISyntaxException, SparqlQueryFailed, IOException {
+    protected String getSparqlInsertQuery(QanaryQuestion<String> myQanaryQuestion, GAnswerResult result, int index) throws QanaryExceptionNoOrMultipleQuestions, URISyntaxException, SparqlQueryFailed, IOException {
 
         String answerSparql = cleanStringForSparqlQuery(result.getSparql());
 
@@ -208,6 +209,7 @@ import java.util.List;
         bindings.add("targetQuestion", ResourceFactory.createResource(myQanaryQuestion.getUri().toASCIIString()));
         bindings.add("selectQueryThatShouldComputeTheAnswer", ResourceFactory.createStringLiteral(answerSparql));
         bindings.add("confidence", ResourceFactory.createTypedLiteral(result.getConfidence()));
+        bindings.add("index", ResourceFactory.createTypedLiteral(index));
         bindings.add("application", ResourceFactory.createResource("urn:qanary:" + this.applicationName));
 
         // get the template of the INSERT query

--- a/qanary-component-QB-PlatypusWrapper/pom.xml
+++ b/qanary-component-QB-PlatypusWrapper/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.wdaqua.qanary.component</groupId>
     <artifactId>qanary-component-QB-PlatypusWrapper</artifactId>
-    <version>3.3.4</version>
+    <version>3.3.5</version>
 
     <parent>
         <groupId>eu.wdaqua.qanary</groupId>

--- a/qanary-component-QB-PlatypusWrapper/src/main/java/eu/wdaqua/qanary/component/platypuswrapper/qb/PlatypusQueryBuilder.java
+++ b/qanary-component-QB-PlatypusWrapper/src/main/java/eu/wdaqua/qanary/component/platypuswrapper/qb/PlatypusQueryBuilder.java
@@ -150,7 +150,8 @@ import java.util.List;
         // STEP 3: add information to Qanary triplestore
         //String sparql = getSparqlInsertQuery(myQanaryQuestion, result);
         //myQanaryUtils.getQanaryTripleStoreConnector().update(sparql);
-        QuerySolutionMap bindings = populateBindings(myQanaryQuestion, result);
+        int index = 0; // only one query expected
+        QuerySolutionMap bindings = populateBindings(myQanaryQuestion, result, index);
         String insertAnswerSPARQL = getSparqlInsertQueryForAnswerSPARQL(bindings);
         String insertTypedLiteral = getSparqlInsertQueryForTypedLiteral(bindings);
         myQanaryUtils.getQanaryTripleStoreConnector().update(insertAnswerSPARQL);
@@ -257,7 +258,7 @@ import java.util.List;
         return sparql;
     }
 
-    protected QuerySolutionMap populateBindings(QanaryQuestion<String> myQanaryQuestion, PlatypusResult result) throws QanaryExceptionNoOrMultipleQuestions, URISyntaxException, SparqlQueryFailed {
+    protected QuerySolutionMap populateBindings(QanaryQuestion<String> myQanaryQuestion, PlatypusResult result, int index) throws QanaryExceptionNoOrMultipleQuestions, URISyntaxException, SparqlQueryFailed {
 
         String answerSparql = cleanStringForSparqlQuery(result.getSparql());
 
@@ -268,6 +269,7 @@ import java.util.List;
         bindings.add("targetQuestion", ResourceFactory.createResource(myQanaryQuestion.getUri().toASCIIString()));
         bindings.add("selectQueryThatShouldComputeTheAnswer", ResourceFactory.createStringLiteral(answerSparql));
         bindings.add("confidence", ResourceFactory.createTypedLiteral(result.getConfidence()));
+        bindings.add("index", ResourceFactory.createTypedLiteral(index));
         bindings.add("application", ResourceFactory.createResource("urn:qanary:" + this.applicationName));
         // TODO: add result value with correct datatype
         // TODO: how does this handle a *list* of values? 

--- a/qanary-component-QB-QAnswer/pom.xml
+++ b/qanary-component-QB-QAnswer/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.wdaqua.qanary.component</groupId>
     <artifactId>qanary-component-QB-QAnswer</artifactId>
-    <version>4.1.1</version>
+    <version>4.2.0</version>
 
     <parent>
         <groupId>eu.wdaqua.qanary</groupId>

--- a/qanary-component-QB-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qb/QAnswerQueryBuilderAndSparqlResultFetcher.java
+++ b/qanary-component-QB-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qb/QAnswerQueryBuilderAndSparqlResultFetcher.java
@@ -137,10 +137,25 @@ public class QAnswerQueryBuilderAndSparqlResultFetcher extends QanaryComponent {
         // STEP 1: get the required data from the Qanary triplestore (the global process
         // memory)
         QanaryQuestion<String> myQanaryQuestion = this.getQanaryQuestion(myQanaryMessage);
-        String questionString = myQanaryQuestion.getTextualRepresentation();
-        List<NamedEntity> retrievedNamedEntities = getNamedEntitiesOfQuestion(myQanaryQuestion,
-                myQanaryQuestion.getInGraph());
 
+        String questionString = "";
+        try {
+          questionString = myQanaryQuestion.getTextualRepresentation(lang);
+          logger.info("Using specific textual representation for language {}: {}", lang, questionString);
+        } catch (Exception e) {
+          logger.warn("Could not retrieve specific textual representation for language {}:\n{}", e.getMessage());
+        }
+        // only if no language-specific text could be found
+        if (questionString.length() == 0){
+            try {
+                questionString = myQanaryQuestion.getTextualRepresentation();
+                logger.info("Using default textual representation {}", questionString);
+            } catch (Exception e) {
+                logger.warn("Could not retrieve textual representation:\n{}", e.getMessage());
+                // stop processing of the question, as it will not work without a question text
+                return myQanaryMessage;
+            }
+        }
     
         // STEP 2: compute new information about the question
 

--- a/qanary-component-QB-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qb/QAnswerQueryBuilderAndSparqlResultFetcher.java
+++ b/qanary-component-QB-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qb/QAnswerQueryBuilderAndSparqlResultFetcher.java
@@ -341,6 +341,7 @@ public class QAnswerQueryBuilderAndSparqlResultFetcher extends QanaryComponent {
             bindings.add("targetQuestion", ResourceFactory.createResource(questionUri.toASCIIString()));
             bindings.add("selectQueryThatShouldComputeTheAnswer", ResourceFactory.createStringLiteral(queryCandidate.getQueryString()));
             bindings.add("confidence", ResourceFactory.createTypedLiteral(queryCandidate.getScore()));
+            bindings.add("index", ResourceFactory.createTypedLiteral(queryCandidate.getIndex()));
             bindings.add("application", ResourceFactory.createResource("urn:qanary:" + this.applicationName));
 
             // get the template of the INSERT query

--- a/qanary-component-QB-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qb/messages/QAnswerResult.java
+++ b/qanary-component-QB-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qb/messages/QAnswerResult.java
@@ -48,11 +48,13 @@ public class QAnswerResult {
 
         JsonArray queryCandidatesArray = parsedJsonObject.getAsJsonArray("queries").getAsJsonArray();
 
-        for (JsonElement queryCandidate : queryCandidatesArray) {
+        for (int i = 0; i < queryCandidatesArray.size(); i++) {
+            JsonElement queryCandidate = queryCandidatesArray.get(i);
             JsonObject queryCandidateObject = queryCandidate.getAsJsonObject(); 
             String query = queryCandidateObject.get("query").getAsString();
             float score = queryCandidateObject.get("confidence").getAsFloat();
-            QAnswerQueryCandidate candidate = new QAnswerQueryCandidate(query, score);
+            int index = i;
+            QAnswerQueryCandidate candidate = new QAnswerQueryCandidate(query, index, score);
             queryCandidates.add(candidate);
         }
 
@@ -86,10 +88,12 @@ public class QAnswerResult {
     public class QAnswerQueryCandidate {
         private String query;
         private float score;
+        private int index;
 
-        public QAnswerQueryCandidate(String query, float score) {
+        public QAnswerQueryCandidate(String query, int index, float score) {
             this.query = query;
             this.score = score;
+            this.index = index;
         }
 
         public String getQueryString() {
@@ -98,6 +102,10 @@ public class QAnswerResult {
 
         public float getScore() {
             return this.score;
+        }
+
+        public int getIndex() {
+            return this.index;
         }
     }
 

--- a/qanary-component-QB-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qb/messages/QAnswerResult.java
+++ b/qanary-component-QB-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qb/messages/QAnswerResult.java
@@ -11,10 +11,8 @@ import org.slf4j.LoggerFactory;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 
 import io.swagger.v3.oas.annotations.Hidden;
-import net.minidev.json.JSONObject;
 
 public class QAnswerResult {
     private static final Logger logger = LoggerFactory.getLogger(QAnswerResult.class);
@@ -27,12 +25,8 @@ public class QAnswerResult {
     private String question;
     private List<QAnswerQueryCandidate> queryCandidates;
 
-    public QAnswerResult(JSONObject json, String question, URI endpoint, String language, String knowledgebaseId, String user)
+    public QAnswerResult(JsonObject json, String question, URI endpoint, String language, String knowledgebaseId, String user)
             throws URISyntaxException {
-
-        logger.debug("result: {}", json.toJSONString());
-
-        JsonObject parsedJsonObject = JsonParser.parseString(json.toJSONString()).getAsJsonObject();
 
         this.question = question;
         this.language = language;
@@ -41,7 +35,7 @@ public class QAnswerResult {
         this.endpoint = endpoint;
         this.queryCandidates = new LinkedList<QAnswerQueryCandidate>();
 
-        initData(parsedJsonObject);
+        initData(json);
     }
 
     /**

--- a/qanary-component-QB-QAnswer/src/main/resources/config/application.properties
+++ b/qanary-component-QB-QAnswer/src/main/resources/config/application.properties
@@ -52,4 +52,4 @@ server.ssl.enabled=false
 # to deactivate set maximumSize to 0 
 qanary.webservicecalls.cache.specs=maximumSize=100000,expireAfterAccess=7d
 # enable/disable testing of live endpoints during the build process
-test.live.endpoints=false
+test.live.endpoints=true

--- a/qanary-component-QB-QAnswer/src/main/resources/config/application.properties
+++ b/qanary-component-QB-QAnswer/src/main/resources/config/application.properties
@@ -52,4 +52,4 @@ server.ssl.enabled=false
 # to deactivate set maximumSize to 0 
 qanary.webservicecalls.cache.specs=maximumSize=100000,expireAfterAccess=7d
 # enable/disable testing of live endpoints during the build process
-test.live.endpoints=true
+test.live.endpoints=false

--- a/qanary-component-QB-RuBQWrapper/pom.xml
+++ b/qanary-component-QB-RuBQWrapper/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.wdaqua.qanary.component</groupId>
     <artifactId>qanary-component-QB-RuBQWrapper</artifactId>
-    <version>3.2.4</version>
+    <version>3.2.5</version>
 
     <parent>
         <groupId>eu.wdaqua.qanary</groupId>

--- a/qanary-component-QB-RuBQWrapper/src/main/java/eu/wdaqua/qanary/component/rubqwrapper/qb/RuBQQueryBuilder.java
+++ b/qanary-component-QB-RuBQWrapper/src/main/java/eu/wdaqua/qanary/component/rubqwrapper/qb/RuBQQueryBuilder.java
@@ -138,7 +138,8 @@ import java.util.List;
         }
 
         // STEP 3: add information to Qanary triplestore
-        String sparql = getSparqlInsertQuery(myQanaryQuestion, result);
+        int index = 0; // only one query expected
+        String sparql = getSparqlInsertQuery(myQanaryQuestion, result, index);
         myQanaryUtils.getQanaryTripleStoreConnector().update(sparql);
 
         return myQanaryMessage;
@@ -197,7 +198,7 @@ import java.util.List;
      * @throws SparqlQueryFailed
      * @throws IOException
      */
-    protected String getSparqlInsertQuery(QanaryQuestion<String> myQanaryQuestion, RuBQResult result) throws QanaryExceptionNoOrMultipleQuestions, URISyntaxException, SparqlQueryFailed, IOException {
+    protected String getSparqlInsertQuery(QanaryQuestion<String> myQanaryQuestion, RuBQResult result, int index) throws QanaryExceptionNoOrMultipleQuestions, URISyntaxException, SparqlQueryFailed, IOException {
 
         String answerSparql = cleanStringForSparqlQuery(result.getSparql());
 
@@ -208,6 +209,7 @@ import java.util.List;
         bindings.add("targetQuestion", ResourceFactory.createResource(myQanaryQuestion.getUri().toASCIIString()));
         bindings.add("selectQueryThatShouldComputeTheAnswer", ResourceFactory.createStringLiteral(answerSparql));
         bindings.add("confidence", ResourceFactory.createTypedLiteral(result.getConfidence()));
+        bindings.add("index", ResourceFactory.createTypedLiteral(index));
         bindings.add("application", ResourceFactory.createResource("urn:qanary:" + this.applicationName));
 
         // get the template of the INSERT query

--- a/qanary-component-QB-TeBaQaWrapper/pom.xml
+++ b/qanary-component-QB-TeBaQaWrapper/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eu.wdaqua.qanary.component</groupId>
 	<artifactId>qanary-component-QB-TeBaQAWrapper</artifactId>
-	<version>3.2.5</version>
+	<version>3.2.6</version>
 
 	<parent>
 		<groupId>eu.wdaqua.qanary</groupId>

--- a/qanary-component-QB-TeBaQaWrapper/src/main/java/eu/wdaqua/qanary/component/tebaqawrapper/qb/TeBaQAQueryBuilder.java
+++ b/qanary-component-QB-TeBaQaWrapper/src/main/java/eu/wdaqua/qanary/component/tebaqawrapper/qb/TeBaQAQueryBuilder.java
@@ -136,7 +136,8 @@ import java.util.List;
         }
 
         // STEP 3: add information to Qanary triplestore
-        String sparql = getSparqlInsertQuery(myQanaryQuestion, result);
+        int index = 0; // only one query expected
+        String sparql = getSparqlInsertQuery(myQanaryQuestion, result, index);
         myQanaryUtils.getQanaryTripleStoreConnector().update(sparql);
 
         return myQanaryMessage;
@@ -195,7 +196,7 @@ import java.util.List;
      * @throws SparqlQueryFailed
      * @throws IOException
      */
-    protected String getSparqlInsertQuery(QanaryQuestion<String> myQanaryQuestion, TeBaQAResult result) throws QanaryExceptionNoOrMultipleQuestions, URISyntaxException, SparqlQueryFailed, IOException {
+    protected String getSparqlInsertQuery(QanaryQuestion<String> myQanaryQuestion, TeBaQAResult result, int index) throws QanaryExceptionNoOrMultipleQuestions, URISyntaxException, SparqlQueryFailed, IOException {
 
         String answerSparql = cleanStringForSparqlQuery(result.getSparql());
 
@@ -206,6 +207,7 @@ import java.util.List;
         bindings.add("targetQuestion", ResourceFactory.createResource(myQanaryQuestion.getUri().toASCIIString()));
         bindings.add("selectQueryThatShouldComputeTheAnswer", ResourceFactory.createStringLiteral(answerSparql));
         bindings.add("confidence", ResourceFactory.createTypedLiteral(result.getConfidence()));
+        bindings.add("index", ResourceFactory.createTypedLiteral(index));
         bindings.add("application", ResourceFactory.createResource("urn:qanary:" + this.applicationName));
 
         // get the template of the INSERT query

--- a/qanary-component-QBE-QAnswer/pom.xml
+++ b/qanary-component-QBE-QAnswer/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eu.wdaqua.qanary.component</groupId>
 	<artifactId>qanary-component-QBE-QAnswer</artifactId>
-	<version>3.4.1</version>
+	<version>3.5.0</version>
 	<parent>
 		<groupId>eu.wdaqua.qanary</groupId>
 		<artifactId>qa.qanarycomponent-parent</artifactId>

--- a/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/QAnswerQueryBuilderAndExecutor.java
+++ b/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/QAnswerQueryBuilderAndExecutor.java
@@ -164,6 +164,7 @@ public class QAnswerQueryBuilderAndExecutor extends QanaryComponent {
         // STEP 3: add information to Qanary triplestore
         URI graph = myQanaryQuestion.getOutGraph();
         URI questionUri = myQanaryQuestion.getUri();
+
         String sparqlImprovedQuestion = getSparqlInsertQueryForImprovedQuestion(graph, questionUri, result);
         logger.debug("created SPARQL query for improved question: {}", sparqlImprovedQuestion);
         myQanaryUtils.getQanaryTripleStoreConnector().update(sparqlImprovedQuestion);
@@ -232,7 +233,8 @@ public class QAnswerQueryBuilderAndExecutor extends QanaryComponent {
             logger.info("post to endpoint not successful: {}", e);
         }
 
-        return new QAnswerResult(response.getBody(), questionString, uri, lang, knowledgeBaseId, user);
+        return new QAnswerResult(response.getBody(),
+                questionString, uri, lang, knowledgeBaseId, user);
     }
 
     /**

--- a/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/QAnswerQueryBuilderAndExecutor.java
+++ b/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/QAnswerQueryBuilderAndExecutor.java
@@ -1,5 +1,6 @@
 package eu.wdaqua.qanary.component.qanswer.qbe;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -161,8 +162,29 @@ public class QAnswerQueryBuilderAndExecutor extends QanaryComponent {
         QAnswerResult result = requestQAnswerWebService(this.getQanswerEndpoint(), questionStringWithResources, lang, knowledgeBaseId, user);
 
         // STEP 3: add information to Qanary triplestore
-        String sparql = getSparqlInsertQuery(myQanaryQuestion, result, knowledgeBaseId);
-        myQanaryUtils.getQanaryTripleStoreConnector().update(sparql);
+        URI graph = myQanaryQuestion.getOutGraph();
+        URI questionUri = myQanaryQuestion.getUri();
+        String sparqlImprovedQuestion = getSparqlInsertQueryForImprovedQuestion(graph, questionUri, result);
+        logger.debug("created SPARQL query for improved question: {}", sparqlImprovedQuestion);
+        myQanaryUtils.getQanaryTripleStoreConnector().update(sparqlImprovedQuestion);
+
+        String sparqlQueryCandidate = getSparqlInsertQueryForQueryCandidate(graph, questionUri, result);
+        logger.debug("created SPARQL query for query candidate: {}", sparqlQueryCandidate);
+        myQanaryUtils.getQanaryTripleStoreConnector().update(sparqlQueryCandidate);
+
+        String sparqlAnswerJson = getSparqlInsertQueryForAnswerJson(graph, questionUri, result);
+        logger.debug("created SPARQL query for answer json: {}", sparqlAnswerJson);
+        myQanaryUtils.getQanaryTripleStoreConnector().update(sparqlAnswerJson);
+
+        String sparqlAnswerType = getSparqlInsertQueryForAnswerType(graph, questionUri, result);
+        logger.debug("created SPARQL query for answer type: {}", sparqlAnswerType);
+        myQanaryUtils.getQanaryTripleStoreConnector().update(sparqlAnswerType);
+
+
+        // TODO: result json and type
+
+//        String sparql = getSparqlInsertQuery(myQanaryQuestion, result, knowledgeBaseId);
+//        myQanaryUtils.getQanaryTripleStoreConnector().update(sparql);
 
         return myQanaryMessage;
     }
@@ -319,153 +341,123 @@ public class QAnswerQueryBuilderAndExecutor extends QanaryComponent {
     }
 
     /**
-     * creates the SPARQL query for inserting the data into Qanary triplestore
-     * <p>
-     * data can be retrieved via SPARQL 1.1 from the Qanary triplestore using:
+     * creates the SPARQL query for inserting the improved question into Qanary triplestore
      *
-     * <pre>
-     *
-     * SELECT * FROM <YOURGRAPHURI> WHERE {
-     * ?s ?p ?o ;
-     * a ?type.
-     * VALUES ?t {
-     * qa:AnnotationOfAnswerSPARQL qa:SparqlQuery
-     * qa:AnnotationOfImprovedQuestion qa:ImprovedQuestion
-     * qa:AnnotationAnswer qa:Answer
-     * qa:AnnotationOfAnswerType qa:AnswerType
-     * }
-     * }
-     * ORDER BY ?type
-     * </pre>
-     *
-     * @param myQanaryQuestion
+     * @param graph
+     * @param questionUri
      * @param result
      * @return
      * @throws QanaryExceptionNoOrMultipleQuestions
      * @throws URISyntaxException
      * @throws SparqlQueryFailed
+     * @throws IOException
      */
-    private String getSparqlInsertQuery(QanaryQuestion<String> myQanaryQuestion, QAnswerResult result, String usedKnowledgeGraph)
-            throws QanaryExceptionNoOrMultipleQuestions, URISyntaxException, SparqlQueryFailed {
+    public String getSparqlInsertQueryForImprovedQuestion(
+            URI graph, URI questionUri, QAnswerResult result) throws QanaryExceptionNoOrMultipleQuestions, URISyntaxException, SparqlQueryFailed, IOException {
 
+        logger.warn("get query for Improved Question");
         // the computed answer's SPARQL query needs to be cleaned
-        String createdAnswerSparqlQuery = cleanStringForSparqlQuery(result.getSparql());
         String improvedQuestion = cleanStringForSparqlQuery(result.getQuestion());
 
-        String answerValuesAsListFormat = "";
-        int counter = 1; // starts at 1
-        for (String answer : result.getValues()) {
-            // only one consistent type for all answers is expected
-            if (result.isAnswerOfResourceType()) {
-                answerValuesAsListFormat += String.format("; rdf:_%d <%s> ", counter, answer);
-            } else {
-                answerValuesAsListFormat += String.format("; rdf:_%d \"%s\"^^<%s> ", counter, answer,
-                        result.getDatatype());
-            }
-            counter++;
-        }
+        // bind: graph, question, service, improvedQuestionText
+        QuerySolutionMap bindings = new QuerySolutionMap();
+        bindings.add("graph", ResourceFactory.createResource(graph.toASCIIString()));
+        bindings.add("question", ResourceFactory.createResource(questionUri.toASCIIString()));
+        bindings.add("application", ResourceFactory.createResource("urn:qanary:" + this.applicationName));
+        bindings.add("improvedQuestionText", ResourceFactory.createStringLiteral(improvedQuestion));
 
-        QuerySolutionMap bindingsForInsert = new QuerySolutionMap();
-        bindingsForInsert.add("service", ResourceFactory.createResource(this.applicationName));
-        bindingsForInsert.add("question", ResourceFactory.createStringLiteral(myQanaryQuestion.getUri().toASCIIString()));
-        bindingsForInsert.add("score", ResourceFactory.createTypedLiteral(String.valueOf(result.getConfidence()), XSDDatatype.XSDdouble));
-        bindingsForInsert.add("improvedQuestionText", ResourceFactory.createStringLiteral(improvedQuestion));
-        bindingsForInsert.add("sparqlQueryString", ResourceFactory.createStringLiteral(createdAnswerSparqlQuery.replace("\"", "\\\"") + "\"") );
-        bindingsForInsert.add("answerDataType", ResourceFactory.createResource(String.valueOf(result.getDatatype())));
-        bindingsForInsert.add("knowledgeGraph", ResourceFactory.createResource(String.valueOf(knowledgeGraphEndpoints.get(usedKnowledgeGraph))));
-        bindingsForInsert.add("json", ResourceFactory.createStringLiteral(
-                result.getJsonString().replace("\"", "\\\"").replace("\\\\", "\\\\\\").replace("\\n", "").replace("\\t", "").replace("\\/", "/")
-        ));
+        String sparql = QanaryTripleStoreConnector.insertAnnotationOfImprovedQuestion(bindings);
+        logger.warn("sparql: {}", sparql);
 
+        return sparql;
+    }
 
-        // TODO: Move to qanary.commons and use template queries
-        String sparql = "" //
-                + "PREFIX qa: <http://www.wdaqua.eu/qa#> \n" //
-                + "PREFIX oa: <http://www.w3.org/ns/openannotation/core/> \n" //
-                + "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> \n" //
-                + "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \n" //
-                + "INSERT { \n" //
-                + "GRAPH <" + myQanaryQuestion.getOutGraph() + "> { \n" //
-                // used SPARQL query
-                + "  ?annotationSPARQL a 	qa:AnnotationOfAnswerSPARQL ; \n" //
-                + " 		oa:hasTarget    ?question ; \n" //
-                + " 		oa:hasBody      ?sparql ; \n" //
-                + " 		oa:annotatedBy  ?service ; \n" //
-                + " 		oa:annotatedAt  ?time ; \n" //
-                + " 		qa:score        ?score ; \n" //
-                + " 		qa:overKnowledgeGraph ?knowledgeGraph . \n" //
-                //
-                + "  ?sparql a              qa:SparqlQuery ; \n" //
-                + "         rdf:value       ?sparqlQueryString . \n" //
-                // improved question
-                + "  ?annotationImprovedQuestion  a 	qa:AnnotationOfImprovedQuestion ; \n" //
-                + " 		oa:hasTarget    ?question ; \n" //
-                + " 		oa:hasBody      ?improvedQuestion ; \n" //
-                + " 		oa:annotatedBy  ?service ; \n" //
-                + " 		oa:annotatedAt  ?time ; \n" //
-                + " 		qa:score        ?score . \n" //
-                //
-                + "  ?improvedQuestion a    qa:ImprovedQuestion ; \n " //
-                + " 		rdf:value 		?improvedQuestionText . \n " //
-                // answer
-                + "  ?annotationAnswer a    qa:AnnotationAnswer ; \n" //
-                + " 		oa:hasTarget    ?question ; \n" //
-                + " 		oa:hasBody      ?answer ; \n" //
-                + " 		oa:annotatedBy  ?service ; \n" //
-                + " 		oa:annotatedAt  ?time ; \n" //
-                + " 		qa:score        ?score . \n" //
-                //
-                + "  ?answer a              qa:Answer ; \n" //
-                + " 		rdf:value       [ a rdf:Seq " + answerValuesAsListFormat + " ]  . \n" //
-                // answer type
-                + "  ?annotationAnswerType a qa:AnnotationOfAnswerType ; \n" //
-                + " 		oa:hasTarget    ?question ; \n" //
-                + " 		oa:hasBody      ?annotationOfAnswerType ; \n" //
-                + " 		oa:annotatedBy  ?service ; \n" //
-                + " 		oa:annotatedAt  ?time ; \n" //
-                + " 		qa:score        ?score . \n" //
-                //
-                + "  ?answerType a          qa:AnswerType ; \n" //
-                + " 		rdf:value       ?answerDataType . \n" //
-                // JSON answer (GERBIL)
-                + "  ?annotationAnswerJson a qa:AnnotationOfAnswerJson ; \n" //
-                + " 		oa:hasTarget    ?question ; \n" //
-                + "         oa:hasBody      ?answerJson ; \n " //
-                + " 		oa:annotatedBy  ?service ; \n" //
-                + " 		oa:annotatedAt  ?time ; \n" //
-                + " 		qa:score        ?score . \n" //
-                //
-                + "  ?answerJson rdf:value  ?json . \n " //
-                + "	}\n" // end: graph
-                + "}\n" // end: insert
-                + "WHERE { \n" //
-                + "  BIND (IRI(str(RAND())) AS ?annotationSPARQL) . \n" //
-                + "  BIND (IRI(str(RAND())) AS ?sparql) . \n" //
-                //
-                + "  BIND (IRI(str(RAND())) AS ?annotationOfAnswerType) . \n" //
-                + "  BIND (IRI(str(RAND())) AS ?answerType) . \n" //
-                //
-                + "  BIND (IRI(str(RAND())) AS ?annotationAnswer) . \n" //
-                + "  BIND (IRI(str(RAND())) AS ?answer) . \n" //
-                //
-                + "  BIND (IRI(str(RAND())) AS ?annotationAnswerJson) . \n" //
-                + "  BIND (IRI(str(RAND())) AS ?answerJson) . \n" //
-                //
-                + "  BIND (IRI(str(RAND())) AS ?annotationImprovedQuestion) . \n" //
-                + "  BIND (IRI(str(RAND())) AS ?improvedQuestion) . \n" //
-                //
-                + "  BIND (now() AS ?time) . \n" //
-                + "  BIND (<" + myQanaryQuestion.getUri().toASCIIString() + "> AS ?question) . \n" //
-                + "  BIND (\"" + result.getConfidence() + "\"^^xsd:double AS ?score) . \n" //
-                + "  BIND (<urn:qanary:" + this.applicationName + "> AS ?service ) . \n" //
-                + "  BIND (\"" + createdAnswerSparqlQuery.replace("\"", "\\\"") + "\"^^xsd:string AS ?sparqlQueryString ) . \n" //
-                + "  BIND (\"" + improvedQuestion + "\"^^xsd:string  AS ?improvedQuestionText ) . \n" //
-                + "  BIND ( <" + result.getDatatype() + "> AS ?answerDataType) . \n" //
-                + "  BIND ( <" + knowledgeGraphEndpoints.get(usedKnowledgeGraph) + "> AS ?knowledgeGraph) . \n" //
-                + "  BIND (\"" + result.getJsonString().replace("\"", "\\\"").replace("\\\\", "\\\\\\").replace("\\n", "").replace("\\t", "").replace("\\/", "/") + "\"^^xsd:string AS ?json ). \n "  //
-                + "}\n";
+    /**
+     * creates the SPARQL query for inserting the query candidate into Qanary triplestore
+     *
+     * @param graph
+     * @param questionUri
+     * @param result
+     * @return
+     * @throws QanaryExceptionNoOrMultipleQuestions
+     * @throws URISyntaxException
+     * @throws SparqlQueryFailed
+     * @throws IOException
+     */
+    public String getSparqlInsertQueryForQueryCandidate(
+            URI graph, URI questionUri, QAnswerResult result) throws QanaryExceptionNoOrMultipleQuestions, URISyntaxException, SparqlQueryFailed, IOException {
 
-        logger.info("SPARQL INSERT for adding data to the Qanary triplestore: ", sparql);
+        QuerySolutionMap bindings = new QuerySolutionMap();
+        // use the variable names defined in method insertAnnotationOfAnswerSPARQL
+        bindings.add("graph", ResourceFactory.createResource(graph.toASCIIString()));
+        bindings.add("targetQuestion", ResourceFactory.createResource(questionUri.toASCIIString()));
+        bindings.add("selectQueryThatShouldComputeTheAnswer", ResourceFactory.createStringLiteral(result.getSparql()));
+        bindings.add("confidence", ResourceFactory.createTypedLiteral(result.getConfidence()));
+        bindings.add("application", ResourceFactory.createResource("urn:qanary:" + this.applicationName));
+
+        // get the template of the INSERT query
+        String sparql = QanaryTripleStoreConnector.insertAnnotationOfAnswerSPARQL(bindings);
+        logger.info("SPARQL insert for adding data to Qanary triplestore: {}", sparql);
+
+        return sparql;
+    }
+
+    /**
+     * creates the SPARQL query for inserting the answer json into Qanary triplestore
+     *
+     * @param graph
+     * @param questionUri
+     * @param result
+     * @return
+     * @throws QanaryExceptionNoOrMultipleQuestions
+     * @throws URISyntaxException
+     * @throws SparqlQueryFailed
+     * @throws IOException
+     */
+    public String getSparqlInsertQueryForAnswerJson(
+            URI graph, URI questionUri, QAnswerResult result) throws QanaryExceptionNoOrMultipleQuestions, URISyntaxException, SparqlQueryFailed, IOException {
+
+        QuerySolutionMap bindings = new QuerySolutionMap();
+        // use the variable names defined in method insertAnnotationOfAnswerSPARQL
+        bindings.add("graph", ResourceFactory.createResource(graph.toASCIIString()));
+        bindings.add("targetQuestion", ResourceFactory.createResource(questionUri.toASCIIString()));
+        // TODO: check content of answer json
+        bindings.add("jsonAnswer", ResourceFactory.createStringLiteral(result.getAnswerJsonString())); 
+        bindings.add("application", ResourceFactory.createResource("urn:qanary:" + this.applicationName));
+
+        // get the template of the INSERT query
+        String sparql = QanaryTripleStoreConnector.insertAnnotationOfAnswerJson(bindings);
+        logger.info("SPARQL insert for adding data to Qanary triplestore: {}", sparql);
+
+        return sparql;
+    }
+
+    /**
+     * creates the SPARQL query for inserting the answer type into Qanary triplestore
+     *
+     * @param graph
+     * @param questionUri
+     * @param result
+     * @return
+     * @throws QanaryExceptionNoOrMultipleQuestions
+     * @throws URISyntaxException
+     * @throws SparqlQueryFailed
+     * @throws IOException
+     */
+    public String getSparqlInsertQueryForAnswerType(
+            URI graph, URI questionUri, QAnswerResult result) throws QanaryExceptionNoOrMultipleQuestions, URISyntaxException, SparqlQueryFailed, IOException {
+
+        QuerySolutionMap bindings = new QuerySolutionMap();
+        // use the variable names defined in method insertAnnotationOfAnswerSPARQL
+        bindings.add("graph", ResourceFactory.createResource(graph.toASCIIString()));
+        bindings.add("targetQuestion", ResourceFactory.createResource(questionUri.toASCIIString()));
+        bindings.add("answerDataType", ResourceFactory.createStringLiteral(result.getType())); 
+        bindings.add("application", ResourceFactory.createResource("urn:qanary:" + this.applicationName));
+
+        // get the template of the INSERT query
+        String sparql = QanaryTripleStoreConnector.insertAnnotationOfAnswerType(bindings);
+        logger.info("SPARQL insert for adding data to Qanary triplestore: {}", sparql);
+
         return sparql;
     }
 

--- a/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/QAnswerQueryBuilderAndExecutor.java
+++ b/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/QAnswerQueryBuilderAndExecutor.java
@@ -473,7 +473,7 @@ public class QAnswerQueryBuilderAndExecutor extends QanaryComponent {
         // use the variable names defined in method insertAnnotationOfAnswerSPARQL
         bindings.add("graph", ResourceFactory.createResource(graph.toASCIIString()));
         bindings.add("targetQuestion", ResourceFactory.createResource(questionUri.toASCIIString()));
-        bindings.add("answerDataType", ResourceFactory.createStringLiteral(result.getType())); 
+        bindings.add("answerDataType", ResourceFactory.createResource(result.getDatatype().toString())); 
         bindings.add("application", ResourceFactory.createResource("urn:qanary:" + this.applicationName));
 
         // get the template of the INSERT query

--- a/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/QAnswerQueryBuilderAndExecutor.java
+++ b/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/QAnswerQueryBuilderAndExecutor.java
@@ -458,7 +458,7 @@ public class QAnswerQueryBuilderAndExecutor extends QanaryComponent {
         bindings.add("application", ResourceFactory.createResource("urn:qanary:" + this.applicationName));
 
         // get the template of the INSERT query
-        String sparql = QanaryTripleStoreConnector.insertAnnotationOfAnswerType(bindings);
+        String sparql = QanaryTripleStoreConnector.insertAnnotationOfAnswerDataType(bindings);
         logger.info("SPARQL insert for adding data to Qanary triplestore: {}", sparql);
 
         return sparql;

--- a/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/QAnswerQueryBuilderAndExecutor.java
+++ b/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/QAnswerQueryBuilderAndExecutor.java
@@ -395,6 +395,7 @@ public class QAnswerQueryBuilderAndExecutor extends QanaryComponent {
         bindings.add("targetQuestion", ResourceFactory.createResource(questionUri.toASCIIString()));
         bindings.add("selectQueryThatShouldComputeTheAnswer", ResourceFactory.createStringLiteral(result.getSparql()));
         bindings.add("confidence", ResourceFactory.createTypedLiteral(result.getConfidence()));
+        bindings.add("index", ResourceFactory.createTypedLiteral(0)); // TODO: currently, only one SPARQL is annotated, so index is always 0
         bindings.add("application", ResourceFactory.createResource("urn:qanary:" + this.applicationName));
 
         // get the template of the INSERT query

--- a/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/QAnswerQueryBuilderAndExecutor.java
+++ b/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/QAnswerQueryBuilderAndExecutor.java
@@ -187,7 +187,8 @@ public class QAnswerQueryBuilderAndExecutor extends QanaryComponent {
         logger.debug("created SPARQL query for improved question: {}", sparqlImprovedQuestion);
         myQanaryUtils.getQanaryTripleStoreConnector().update(sparqlImprovedQuestion);
 
-        String sparqlQueryCandidate = getSparqlInsertQueryForQueryCandidate(graph, questionUri, result);
+        int index = 0; // only one query expected
+        String sparqlQueryCandidate = getSparqlInsertQueryForQueryCandidate(graph, questionUri, result, index);
         logger.debug("created SPARQL query for query candidate: {}", sparqlQueryCandidate);
         myQanaryUtils.getQanaryTripleStoreConnector().update(sparqlQueryCandidate);
 
@@ -405,7 +406,7 @@ public class QAnswerQueryBuilderAndExecutor extends QanaryComponent {
      * @throws IOException
      */
     public String getSparqlInsertQueryForQueryCandidate(
-            URI graph, URI questionUri, QAnswerResult result) throws QanaryExceptionNoOrMultipleQuestions, URISyntaxException, SparqlQueryFailed, IOException {
+            URI graph, URI questionUri, QAnswerResult result, int index) throws QanaryExceptionNoOrMultipleQuestions, URISyntaxException, SparqlQueryFailed, IOException {
 
         QuerySolutionMap bindings = new QuerySolutionMap();
         // use the variable names defined in method insertAnnotationOfAnswerSPARQL
@@ -413,7 +414,7 @@ public class QAnswerQueryBuilderAndExecutor extends QanaryComponent {
         bindings.add("targetQuestion", ResourceFactory.createResource(questionUri.toASCIIString()));
         bindings.add("selectQueryThatShouldComputeTheAnswer", ResourceFactory.createStringLiteral(result.getSparql()));
         bindings.add("confidence", ResourceFactory.createTypedLiteral(result.getConfidence()));
-        bindings.add("index", ResourceFactory.createTypedLiteral(0)); // TODO: currently, only one SPARQL is annotated, so index is always 0
+        bindings.add("index", ResourceFactory.createTypedLiteral(index)); // TODO: currently, only one SPARQL is annotated, so index is always 0
         bindings.add("application", ResourceFactory.createResource("urn:qanary:" + this.applicationName));
 
         // get the template of the INSERT query

--- a/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/messages/QAnswerResult.java
+++ b/qanary-component-QBE-QAnswer/src/main/java/eu/wdaqua/qanary/component/qanswer/qbe/messages/QAnswerResult.java
@@ -29,6 +29,7 @@ public class QAnswerResult {
     private String question;
     private String sparql;
     private List<String> values;
+    private String answerJsonString;
     private String type;
     private URI datatype;
     private double confidence;
@@ -98,13 +99,17 @@ public class QAnswerResult {
         JsonArray languages = questionData.get("language").getAsJsonArray();
         logger.debug("responseQuestion->language: {}", languages.toString());
 
+        String answerJson = questionData.get("answers").getAsString();
+
         JsonObject language = languages.get(0).getAsJsonObject();
         logger.debug("0. language: {}", language.toString());
         logger.debug("0. sparql: {}", language.get("SPARQL").getAsString());
+        logger.debug("0. answer json: {}", answerJson);
         logger.debug("0. confidence: {}", language.get("confidence").getAsDouble());
 
         this.confidence = language.get("confidence").getAsDouble();
         this.sparql = language.get("SPARQL").getAsString();
+        this.answerJsonString = answerJson;
 
     }
 
@@ -302,5 +307,9 @@ public class QAnswerResult {
 
     public String getJsonString() {
         return jsonString;
+    }
+
+    public String getAnswerJsonString(){
+        return answerJsonString;
     }
 }

--- a/qanary-component-QE-SparqlExecuter/pom.xml
+++ b/qanary-component-QE-SparqlExecuter/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eu.wdaqua.qanary.component</groupId>
 	<artifactId>qanary-component-QE-SparqlExecuter</artifactId>
-	<version>3.2.3</version>
+	<version>3.3.0</version>
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>

--- a/qanary-component-QE-SparqlExecuter/src/main/java/eu/wdaqua/qanary/sparqlexecuter/SparqlExecuter.java
+++ b/qanary-component-QE-SparqlExecuter/src/main/java/eu/wdaqua/qanary/sparqlexecuter/SparqlExecuter.java
@@ -125,8 +125,7 @@ public class SparqlExecuter extends QanaryComponent {
     }
 
     public String getResultSparqlQuery(QanaryUtils myQanaryUtils, QanaryQuestion myQanaryQuestion) throws SparqlQueryFailed, IOException{
-        // TODO: this was changed (no longer using QanaryMessage.getInGraph())
-        ResultSet resultset = myQanaryUtils.getQanaryTripleStoreConnector().select(QanaryTripleStoreConnector.getHighestScoreAnnotationOfAnswerInGraph(myQanaryQuestion.getOutGraph()));
+        ResultSet resultset = myQanaryUtils.getQanaryTripleStoreConnector().select(QanaryTripleStoreConnector.getLowestIndexAnnotationOfAnswerInGraph(myQanaryQuestion.getOutGraph()));
         String sparqlQuery = "";
         while (resultset.hasNext()) {
             sparqlQuery = resultset.next().get("selectQueryThatShouldComputeTheAnswer").toString().replace("\\\"", "\"").replace("\\n", "\n");


### PR DESCRIPTION
[#366](https://github.com/WSE-research/team-tasks/issues/366)

QAnswer QB and QBE components now use methods from the Qanary commons package to create SPARQL INSERT queries. 

Requires changes to `QanaryTripleStoreConnector`, made in [PR 265](https://github.com/WDAqua/Qanary/pull/265)