### PR TITLE
Update test for created SPARQL INSERT queries in Pthon MT components 

### DIFF
--- a/qanary-component-MT-Python-HelsinkiNLP/pytest.ini
+++ b/qanary-component-MT-Python-HelsinkiNLP/pytest.ini
@@ -1,6 +1,8 @@
 [pytest]
-log_cli = True
+log_cli = 1
 log_cli_level = INFO
+log_cli_format = %(asctime)s [%(levelname)8s] [%(filename)s:%(lineno)s] %(message)s 
+log_cli_date_format=%Y-%m-%d %H:%M:%S
 env = 
     SPRING_BOOT_ADMIN_URL=https://localhost:43740
     SPRING_BOOT_ADMIN_USERNAME=admin

--- a/qanary-component-MT-Python-LibreTranslate/pytest.ini
+++ b/qanary-component-MT-Python-LibreTranslate/pytest.ini
@@ -1,3 +1,15 @@
 [pytest]
-log_cli = True
+log_cli = 1
 log_cli_level = INFO
+log_cli_format = %(asctime)s [%(levelname)8s] [%(filename)s:%(lineno)s] %(message)s 
+log_cli_date_format=%Y-%m-%d %H:%M:%S
+env = 
+  SERVER_PORT=40120
+  SPRING_BOOT_ADMIN_URL=http://qanary-pipeline-host:40111
+  SERVER_HOST=http://public-component-host
+  SPRING_BOOT_ADMIN_USERNAME=admin
+  SPRING_BOOT_ADMIN_PASSWORD=admin
+  SERVICE_NAME_COMPONENT=LibreTranslate
+  TRANSLATE_ENDPOINT=http://localhost:5000/translate
+  LANGUAGES_ENDPOINT=http://localhost:5000/languages
+  SOURCE_LANGUAGE=

--- a/qanary-component-MT-Python-LibreTranslate/requirements.txt
+++ b/qanary-component-MT-Python-LibreTranslate/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.2.2
+Flask
 langdetect==1.0.9
 langid==1.1.6
 mock==3.0.5
@@ -6,3 +6,4 @@ python-dotenv==0.21.1
 qanary_helpers==0.2.2
 gunicorn==20.1.0
 pytest
+pytest-env

--- a/qanary-component-MT-Python-LibreTranslate/tests/test_mt_libretranslate.py
+++ b/qanary-component-MT-Python-LibreTranslate/tests/test_mt_libretranslate.py
@@ -9,12 +9,13 @@ class TestComponent(TestCase):
 
     logging.basicConfig(format='%(asctime)s - %(message)s', level=logging.INFO)
 
-    questions = list([{"uri": "urn:test-uri", "text": "test_input"}])
+    questions = list([{"uri": "urn:test-uri", "text": "was ist ein Test?"}])
     endpoint = "urn:qanary#test-endpoint"
     in_graph = "urn:qanary#test-inGraph"
     out_graph = "urn:qanary#test-outGraph"
 
-    source_language = "en"
+    source_language = "de"
+    target_language = "en"
 
     test_translation_placeholder = "test_translation"
 
@@ -49,21 +50,32 @@ class TestComponent(TestCase):
             # when a call to /annotatequestion is made
             response_json = client.post("/annotatequestion", headers = self.headers, data = self.request_data)
 
-            # then
-            # the text question is retrieved from the triplestore
+            # then the text question is retrieved from the triplestore
             mocked_get_text_question_in_graph.assert_called_with(triplestore_endpoint=self.endpoint, graph=self.in_graph)
 
-            # new information is pushed to the triplestore 
-            mocked_insert_into_triplestore.assert_called()
+            # get arguments of the (2) separate insert calls 
+            arg_list = mocked_insert_into_triplestore.call_args_list
+            # get the call arguments for question translation
+            call_args_translation = [a.args for a in arg_list if "AnnotationOfQuestionTranslation" in a.args[1]]
+            assert len(call_args_translation) == 1
+            # get the call arguments for question language
+            call_args_language = [a.args for a in arg_list if "AnnotationOfQuestionLanguage" in a.args[1]]
+            assert len(call_args_language) == 1
 
-            args = mocked_insert_into_triplestore.call_args.args
-            query_stored = re.sub(r"(\\n\W*|\n\W*)", " ", args[1])
+            # clean query strings
+            query_translation = re.sub(r"(\\n\W*|\n\W*)", " ", call_args_translation[0][1])
+            query_language = re.sub(r"(\\n\W*|\n\W*)", " ", call_args_language[0][1])
 
-            # the source language is correctly identified and annotated
-            self.assertRegex(query_stored, r".*AnnotationOfQuestionLanguage(.*;\W?)*oa:hasBody \""+self.source_language+r"\".*\.")
-            # the question is translated and the result is annotated
-            assert self.test_translation_placeholder in query_stored.lower()
+            # then the triplestore is updated twice 
+            # (question language and translation)
+            assert mocked_insert_into_triplestore.call_count == 2
 
-            # the response is not empty
+            # then the source language is correctly identified and annotated
+            self.assertRegex(query_language, r".*AnnotationOfQuestionLanguage(.*;\W?)*oa:hasBody \""+self.source_language+r"\".*\.")
+
+            # then the question is translated and the result is annotated
+            self.assertRegex(query_translation, r".*AnnotationOfQuestionTranslation(.*;\W?)*oa:hasBody \".*\"@" + self.target_language + r".*\.")
+            assert "@"+self.target_language in query_translation.lower()
+
+            # then the response is not empty
             assert response_json != None
-

--- a/qanary-component-MT-Python-MBart/pytest.ini
+++ b/qanary-component-MT-Python-MBart/pytest.ini
@@ -1,6 +1,8 @@
 [pytest]
-log_cli = True
+log_cli = 1
 log_cli_level = INFO
+log_cli_format = %(asctime)s [%(levelname)8s] [%(filename)s:%(lineno)s] %(message)s 
+log_cli_date_format=%Y-%m-%d %H:%M:%S
 env =
   SERVER_PORT=40120
   SPRING_BOOT_ADMIN_URL=http://qanary-pipeline-host:40111

--- a/qanary-component-MT-Python-MBart/tests/test_mt_mbart_nlp.py
+++ b/qanary-component-MT-Python-MBart/tests/test_mt_mbart_nlp.py
@@ -1,7 +1,6 @@
 from component.mt_mbart_nlp import *
 from component import app
 from unittest.mock import patch
-import mock 
 import re
 from unittest import TestCase
 
@@ -16,16 +15,16 @@ class TestComponent(TestCase):
     out_graph = "urn:qanary#test-outGraph"
 
     source_language = "de"
-    question_translation = "what is a test?"
+    target_language = "en"
 
     request_data = '''{
         "values": {
-            "urn:qanary#endpoint": "urn:qanary#test-endpoint", 
-            "urn:qanary#inGraph": "urn:qanary#test-inGraph", 
+            "urn:qanary#endpoint": "urn:qanary#test-endpoint",
+            "urn:qanary#inGraph": "urn:qanary#test-inGraph",
             "urn:qanary#outGraph": "urn:qanary#test-outGraph"
         },
-        "endpoint": "urn:qanary#test-endpoint", 
-        "inGraph": "urn:qanary#test-inGraph", 
+        "endpoint": "urn:qanary#test-endpoint",
+        "inGraph": "urn:qanary#test-inGraph",
         "outGrpah": "urn:qanary#test-outGraph"
     }'''
 
@@ -47,20 +46,32 @@ class TestComponent(TestCase):
             # when a call to /annotatequestion is made
             response_json = client.post("/annotatequestion", headers = self.headers, data = self.request_data)
 
-            # then
-            # the text question is retrieved from the triplestore
+            # then the text question is retrieved from the triplestore
             mocked_get_text_question_in_graph.assert_called_with(triplestore_endpoint=self.endpoint, graph=self.in_graph)
 
-            # new information is pushed to the triplestore 
-            mocked_insert_into_triplestore.assert_called()
+            # get arguments of the (2) separate insert calls 
+            arg_list = mocked_insert_into_triplestore.call_args_list
+            # get the call arguments for question translation
+            call_args_translation = [a.args for a in arg_list if "AnnotationOfQuestionTranslation" in a.args[1]]
+            assert len(call_args_translation) == 1
+            # get the call arguments for question language
+            call_args_language = [a.args for a in arg_list if "AnnotationOfQuestionLanguage" in a.args[1]]
+            assert len(call_args_language) == 1
 
-            args = mocked_insert_into_triplestore.call_args.args
-            query_stored = re.sub(r"(\\n\W*|\n\W*)", " ", args[1])
+            # clean query strings
+            query_translation = re.sub(r"(\\n\W*|\n\W*)", " ", call_args_translation[0][1])
+            query_language = re.sub(r"(\\n\W*|\n\W*)", " ", call_args_language[0][1])
 
-            # the source language is correctly identified and annotated
-            self.assertRegex(query_stored, r".*AnnotationOfQuestionLanguage(.*;\W?)*oa:hasBody \""+self.source_language+r"\".*\.")
-            # the question is translated and the result is annotated
-            assert self.question_translation in query_stored.lower()
+            # then the triplestore is updated twice 
+            # (question language and translation)
+            assert mocked_insert_into_triplestore.call_count == 2
 
-            # the response is not empty
+            # then the source language is correctly identified and annotated
+            self.assertRegex(query_language, r".*AnnotationOfQuestionLanguage(.*;\W?)*oa:hasBody \""+self.source_language+r"\".*\.")
+
+            # then the question is translated and the result is annotated
+            self.assertRegex(query_translation, r".*AnnotationOfQuestionTranslation(.*;\W?)*oa:hasBody \".*\"@" + self.target_language + r".*\.")
+            assert "@"+self.target_language in query_translation.lower()
+
+            # then the response is not empty
             assert response_json != None

--- a/qanary-component-MT-Python-NLLB/component/__init__.py
+++ b/qanary-component-MT-Python-NLLB/component/__init__.py
@@ -1,7 +1,7 @@
 from component.mt_nllb import mt_nllb_bp
 from flask import Flask
 
-version = "0.1.2"
+version = "0.1.3"
 
 # default config file
 configfile = "app.conf"

--- a/qanary-component-MT-Python-NLLB/component/mt_nllb.py
+++ b/qanary-component-MT-Python-NLLB/component/mt_nllb.py
@@ -24,7 +24,6 @@ lang_code_map = {
     'es': 'spa_Latn',
     'pt': 'por_Latn'
 }
-target_lang = TARGET_LANG
 
 
 @mt_nllb_bp.route("/annotatequestion", methods=["POST"])
@@ -65,7 +64,7 @@ def qanary_service():
     # Perform the translation and decode the output
     generated_tokens = model.generate(
         **batch,
-        forced_bos_token_id=tokenizer.lang_code_to_id[lang_code_map[target_lang]])
+        forced_bos_token_id=tokenizer.lang_code_to_id[lang_code_map[TARGET_LANG]])
     result = tokenizer.batch_decode(generated_tokens, skip_special_tokens=True)[0]
 
 

--- a/qanary-component-MT-Python-NLLB/component/mt_nllb.py
+++ b/qanary-component-MT-Python-NLLB/component/mt_nllb.py
@@ -37,7 +37,7 @@ def qanary_service():
     logging.info("endpoint: %s, inGraph: %s, outGraph: %s" % \
                  (triplestore_endpoint, triplestore_ingraph, triplestore_outgraph))
 
-    text = get_text_question_in_graph(triplestore_endpoint=triplestore_endpoint, 
+    text = get_text_question_in_graph(triplestore_endpoint=triplestore_endpoint,
                                       graph=triplestore_ingraph)[0]["text"]
     question_uri = get_text_question_in_graph(triplestore_endpoint=triplestore_endpoint,
                                               graph=triplestore_ingraph)[0]["uri"]
@@ -70,63 +70,61 @@ def qanary_service():
 
 
     # building SPARQL query TODO: verify this annotation AnnotationOfQuestionTranslation ??
-        SPARQLqueryAnnotationOfQuestionTranslation = """
-            PREFIX qa: <http://www.wdaqua.eu/qa#>
-            PREFIX oa: <http://www.w3.org/ns/openannotation/core/>
-            PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    SPARQLqueryAnnotationOfQuestionTranslation = """
+        PREFIX qa: <http://www.wdaqua.eu/qa#>
+        PREFIX oa: <http://www.w3.org/ns/openannotation/core/>
+        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-            INSERT {{
-            GRAPH <{uuid}> {{
-                ?a a qa:AnnotationOfQuestionTranslation ;
-                    oa:hasTarget <{qanary_question_uri}> ;
-                    oa:hasBody "{translation_result}"@{target_lang} ;
-                    oa:annotatedBy <urn:qanary:{app_name}> ;
-                    oa:annotatedAt ?time .
+        INSERT {{
+        GRAPH <{uuid}> {{
+            ?a a qa:AnnotationOfQuestionTranslation ;
+                oa:hasTarget <{qanary_question_uri}> ;
+                oa:hasBody "{translation_result}"@{target_lang} ;
+                oa:annotatedBy <urn:qanary:{app_name}> ;
+                oa:annotatedAt ?time .
 
-                }}
             }}
-            WHERE {{
-                BIND (IRI(str(RAND())) AS ?a) .
-                BIND (now() as ?time)
-            }}
-        """.format(
-            uuid=triplestore_ingraph,
-            qanary_question_uri=question_uri,
-            translation_result=result.replace("\"", "\\\""), #keep quotation marks that are part of the translation
-            target_lang=TARGET_LANG,
-            app_name=SERVICE_NAME_COMPONENT
-        )
+        }}
+        WHERE {{
+            BIND (IRI(str(RAND())) AS ?a) .
+            BIND (now() as ?time)
+        }}""".format(
+        uuid=triplestore_ingraph,
+        qanary_question_uri=question_uri,
+        translation_result=result.replace("\"", "\\\""), #keep quotation marks that are part of the translation
+        target_lang=TARGET_LANG,
+        app_name=SERVICE_NAME_COMPONENT
+    )
 
-        SPARQLqueryAnnotationOfQuestionLanguage = """
-            PREFIX qa: <http://www.wdaqua.eu/qa#>
-            PREFIX oa: <http://www.w3.org/ns/openannotation/core/>
-            PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    SPARQLqueryAnnotationOfQuestionLanguage = """
+        PREFIX qa: <http://www.wdaqua.eu/qa#>
+        PREFIX oa: <http://www.w3.org/ns/openannotation/core/>
+        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-            INSERT {{
-            GRAPH <{uuid}> {{
-                ?b a qa:AnnotationOfQuestionLanguage ;
-                    oa:hasTarget <{qanary_question_uri}> ;
-                    oa:hasBody "{src_lang}"^^xsd:string ;
-                    oa:annotatedBy <urn:qanary:{app_name}> ;
-                    oa:annotatedAt ?time .
-                }}
+        INSERT {{
+        GRAPH <{uuid}> {{
+            ?b a qa:AnnotationOfQuestionLanguage ;
+                oa:hasTarget <{qanary_question_uri}> ;
+                oa:hasBody "{src_lang}"^^xsd:string ;
+                oa:annotatedBy <urn:qanary:{app_name}> ;
+                oa:annotatedAt ?time .
             }}
-            WHERE {{
-                BIND (IRI(str(RAND())) AS ?b) .
-                BIND (now() as ?time)
-            }}
-        """.format(
-            uuid=triplestore_ingraph,
-            qanary_question_uri=question_uri,
-            src_lang=lang,
-            app_name=SERVICE_NAME_COMPONENT
-        )
+        }}
+        WHERE {{
+            BIND (IRI(str(RAND())) AS ?b) .
+            BIND (now() as ?time)
+        }}""".format(
+        uuid=triplestore_ingraph,
+        qanary_question_uri=question_uri,
+        src_lang=lang,
+        app_name=SERVICE_NAME_COMPONENT
+    )
 
-        logging.info(f'SPARQL: {SPARQLqueryAnnotationOfQuestionTranslation}')
-        logging.info(f'SPARQL: {SPARQLqueryAnnotationOfQuestionLanguage}')
-        # inserting new data to the triplestore
-        insert_into_triplestore(triplestore_endpoint, SPARQLqueryAnnotationOfQuestionTranslation)
-        insert_into_triplestore(triplestore_endpoint, SPARQLqueryAnnotationOfQuestionLanguage)
+    logging.info(f'SPARQL: {SPARQLqueryAnnotationOfQuestionTranslation}')
+    logging.info(f'SPARQL: {SPARQLqueryAnnotationOfQuestionLanguage}')
+    # inserting new data to the triplestore
+    insert_into_triplestore(triplestore_endpoint, SPARQLqueryAnnotationOfQuestionTranslation)
+    insert_into_triplestore(triplestore_endpoint, SPARQLqueryAnnotationOfQuestionLanguage)
 
     return jsonify(request.get_json())
 

--- a/qanary-component-MT-Python-NLLB/pytest.ini
+++ b/qanary-component-MT-Python-NLLB/pytest.ini
@@ -1,6 +1,8 @@
 [pytest]
-log_cli = True
+log_cli = 1
 log_cli_level = INFO
+log_cli_format = %(asctime)s [%(levelname)8s] [%(filename)s:%(lineno)s] %(message)s 
+log_cli_date_format=%Y-%m-%d %H:%M:%S
 env = 
   SERVER_PORT=40120
   SPRING_BOOT_ADMIN_URL=http://qanary-pipeline-host:40111

--- a/qanary-component-MT-Python-NLLB/tests/test_mt_nllb.py
+++ b/qanary-component-MT-Python-NLLB/tests/test_mt_nllb.py
@@ -19,12 +19,12 @@ class TestComponent(TestCase):
 
     request_data = '''{
         "values": {
-            "urn:qanary#endpoint": "urn:qanary#test-endpoint", 
-            "urn:qanary#inGraph": "urn:qanary#test-inGraph", 
+            "urn:qanary#endpoint": "urn:qanary#test-endpoint",
+            "urn:qanary#inGraph": "urn:qanary#test-inGraph",
             "urn:qanary#outGraph": "urn:qanary#test-outGraph"
         },
-        "endpoint": "urn:qanary#test-endpoint", 
-        "inGraph": "urn:qanary#test-inGraph", 
+        "endpoint": "urn:qanary#test-endpoint",
+        "inGraph": "urn:qanary#test-inGraph",
         "outGrpah": "urn:qanary#test-outGraph"
     }'''
 
@@ -46,20 +46,32 @@ class TestComponent(TestCase):
             # when a call to /annotatequestion is made
             response_json = client.post("/annotatequestion", headers = self.headers, data = self.request_data)
 
-            # then
-            # the text question is retrieved from the triplestore
+            # then the text question is retrieved from the triplestore
             mocked_get_text_question_in_graph.assert_called_with(triplestore_endpoint=self.endpoint, graph=self.in_graph)
 
-            # new information is pushed to the triplestore 
-            mocked_insert_into_triplestore.assert_called()
+            # get arguments of the (2) separate insert calls 
+            arg_list = mocked_insert_into_triplestore.call_args_list
+            # get the call arguments for question translation
+            call_args_translation = [a.args for a in arg_list if "AnnotationOfQuestionTranslation" in a.args[1]]
+            assert len(call_args_translation) == 1
+            # get the call arguments for question language
+            call_args_language = [a.args for a in arg_list if "AnnotationOfQuestionLanguage" in a.args[1]]
+            assert len(call_args_language) == 1
 
-            args = mocked_insert_into_triplestore.call_args.args
-            query_stored = re.sub(r"(\\n\W*|\n\W*)", " ", args[1])
+            # clean query strings
+            query_translation = re.sub(r"(\\n\W*|\n\W*)", " ", call_args_translation[0][1])
+            query_language = re.sub(r"(\\n\W*|\n\W*)", " ", call_args_language[0][1])
 
-            # the source language is correctly identified and annotated
-            self.assertRegex(query_stored, r".*AnnotationOfQuestionLanguage(.*;\W?)*oa:hasBody \""+self.source_language+r"\".*\.")
-            # the question is translated and the result is annotated
-            assert "@"+self.target_language in query_stored.lower()
+            # then the triplestore is updated twice 
+            # (question language and translation)
+            assert mocked_insert_into_triplestore.call_count == 2
 
-            # the response is not empty
+            # then the source language is correctly identified and annotated
+            self.assertRegex(query_language, r".*AnnotationOfQuestionLanguage(.*;\W?)*oa:hasBody \""+self.source_language+r"\".*\.")
+
+            # then the question is translated and the result is annotated
+            self.assertRegex(query_translation, r".*AnnotationOfQuestionTranslation(.*;\W?)*oa:hasBody \".*\"@" + self.target_language + r".*\.")
+            assert "@"+self.target_language in query_translation.lower()
+
+            # then the response is not empty
             assert response_json != None


### PR DESCRIPTION
[#414](https://github.com/WSE-research/team-tasks/issues/414)

Because there are now two separate insert queries - one for `AnnotationOfQuestionLanguage` and one for `AnnotationOfQuestionTranslation` - the test needs to be updated to reflect the new expected behaviour. 