### PR TITLE
Revert "Update build_images.sh"

### DIFF
--- a/service_config/build_images.sh
+++ b/service_config/build_images.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+# clone Qanary pipeline
+git clone https://github.com/WDAqua/Qanary.git
+
+# subshell building the Qanary pipeline
+(
+cd Qanary/
+mvn --batch-mode clean install -Ddockerfile.skip=true -DskipTests -Dgpg.skip=true
+)
+
+# delete Qanary pipeline repository
+rm -rf Qanary/
 
 # replace secrets
 if [ -z "$BABELFY_API_KEY" ]


### PR DESCRIPTION
Reverts WDAqua/Qanary-question-answering-components#352

Error during build process:
The components rely on qanary-component-parent as parent in their pom.xml. As we only made qanary_component, qanary_pipeline and qanary_commons available through maven central, we lack this qanary-component-parent package. 
We either release this artifact too, or, we build it within the build_images.sh