### PR TITLE
Adjusted component's pom files to overwrite parent's inherited values

### DIFF
--- a/qanary-component-CopyValuesOfPriorGraph/pom.xml
+++ b/qanary-component-CopyValuesOfPriorGraph/pom.xml
@@ -25,6 +25,25 @@
 		<springdoc.version>1.7.0</springdoc.version>
 	</properties>
 
+	<!-- META INFORMATION, required due to inheritance from component-parent as parent -->
+	<!-- The name tag is inherited and a composition of the groupID and artifactID -->
+	<url>https://github.com/WDAqua/Qanary-question-answering-components</url>
+	<description>CopyValuesOfPriorGraph is a Qanary component for copying data from a prior process (i.e., prior graph of the Qanary triplestore)</description>
+	<licenses>
+		<license>
+			<name>The Apache License, Version 2.0</name> <!-- Example for Apache2 Licence -->
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url> <!-- Example for Apache2 Licence -->
+		</license>
+	</licenses>
+	<developers>
+		<developer>
+			<name>Andreas Both</name>
+			<email>andreas.both@htwk-leipzig.de</email>
+			<organization>WDAqua</organization>
+			<organizationUrl>http://wdaqua.eu/</organizationUrl>
+		</developer>
+	</developers>
+
 	<dependencies>
 		<!-- https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-data-rest -->
 		<dependency>

--- a/qanary-component-LD-Shuyo/pom.xml
+++ b/qanary-component-LD-Shuyo/pom.xml
@@ -21,6 +21,25 @@
 		<profile_directory>${basedir}/src/main/resources/language-detection/profiles</profile_directory>
 	</properties>
 
+	<!-- META INFORMATION, required due to inheritance from component-parent as parent -->
+	<!-- The name tag is inherited and a composition of the groupID and artifactID -->
+	<url>https://github.com/WDAqua/Qanary-question-answering-components</url>
+	<description>LD-Shuyo is a Qanary component for determining the language of a question stored in the Qanary triplestore. If successful, it will store an instance of qa:AnnotationOfQuestionLanguage in the Qanary triplestore.</description>
+	<licenses>
+		<license>
+			<name>The Apache License, Version 2.0</name> <!-- Example for Apache2 Licence -->
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url> <!-- Example for Apache2 Licence -->
+		</license>
+	</licenses>
+	<developers>
+		<developer>
+			<name>Andreas Both</name>
+			<email>andreas.both@htwk-leipzig.de</email>
+			<organization>WDAqua</organization>
+			<organizationUrl>http://wdaqua.eu/</organizationUrl>
+		</developer>
+	</developers>
+
 	<dependencies>
 		<!-- from dependency management -->
 		<dependency>

--- a/qanary-component-NED-DBpediaSpotlight/pom.xml
+++ b/qanary-component-NED-DBpediaSpotlight/pom.xml
@@ -19,6 +19,26 @@
 		<dockerfile-maven-version>1.4.13</dockerfile-maven-version>
 		<springdoc.version>1.7.0</springdoc.version>
 	</properties>
+
+	<!-- META INFORMATION, required due to inheritance from component-parent as parent -->
+	<!-- The name tag is inherited and a composition of the groupID and artifactID -->
+	<url>https://github.com/WDAqua/Qanary-question-answering-components</url>
+	<description>NED-DBpediaSpotlight is a Qanary component using DBpediaSpotlight to identify Named Entities in a given text</description>
+	<licenses>
+		<license>
+			<name>The Apache License, Version 2.0</name> <!-- Example for Apache2 Licence -->
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url> <!-- Example for Apache2 Licence -->
+		</license>
+	</licenses>
+	<developers>
+		<developer>
+			<name>Andreas Both</name>
+			<email>andreas.both@htwk-leipzig.de</email>
+			<organization>WDAqua</organization>
+			<organizationUrl>http://wdaqua.eu/</organizationUrl>
+		</developer>
+	</developers>
+
 	<dependencies>
 		<!-- https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-data-rest -->
 		<dependency>

--- a/qanary-component-NED-OpenAI-GPT/pom.xml
+++ b/qanary-component-NED-OpenAI-GPT/pom.xml
@@ -19,6 +19,25 @@
 		<dockerfile-maven-version>1.4.13</dockerfile-maven-version>
 	</properties>
 
+	<!-- META INFORMATION, required due to inheritance from component-parent as parent -->
+	<!-- The name tag is inherited and a composition of the groupID and artifactID -->
+	<url>https://github.com/WDAqua/Qanary-question-answering-components</url>
+	<description>NED-basedOnOpenAIGpt is a Qanary component for NED based on Open AI's GPT API</description>
+	<licenses>
+		<license>
+			<name>The Apache License, Version 2.0</name> <!-- Example for Apache2 Licence -->
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url> <!-- Example for Apache2 Licence -->
+		</license>
+	</licenses>
+	<developers>
+		<developer>
+			<name>Andreas Both</name>
+			<email>andreas.both@htwk-leipzig.de</email>
+			<organization>WDAqua</organization>
+			<organizationUrl>http://wdaqua.eu/</organizationUrl>
+		</developer>
+	</developers>
+
 	<dependencies>
 		<dependency>
 			<groupId>com.jayway.jsonpath</groupId>

--- a/qanary-component-NED-Opentapioca/pom.xml
+++ b/qanary-component-NED-Opentapioca/pom.xml
@@ -21,6 +21,25 @@
 		<springdoc.version>1.7.0</springdoc.version>
 	</properties>
 
+	<!-- META INFORMATION, required due to inheritance from component-parent as parent -->
+	<!-- The name tag is inherited and a composition of the groupID and artifactID -->
+	<url>https://github.com/WDAqua/Qanary-question-answering-components</url>
+	<description>NED-Opentapioca is a Qanary component for identifying Wikidata entities in a given text</description>
+	<licenses>
+		<license>
+			<name>The Apache License, Version 2.0</name> <!-- Example for Apache2 Licence -->
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url> <!-- Example for Apache2 Licence -->
+		</license>
+	</licenses>
+	<developers>
+		<developer>
+			<name>Andreas Both</name>
+			<email>andreas.both@htwk-leipzig.de</email>
+			<organization>WDAqua</organization>
+			<organizationUrl>http://wdaqua.eu/</organizationUrl>
+		</developer>
+	</developers>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/qanary-component-QB-BirthDataWikidata/pom.xml
+++ b/qanary-component-QB-BirthDataWikidata/pom.xml
@@ -11,6 +11,26 @@
 		<artifactId>qa.qanarycomponent-parent</artifactId>
 		<version>[0.1.0,1.0.0)</version>
 	</parent>
+
+	<!-- META INFORMATION, required due to inheritance from component-parent as parent -->
+	<!-- The name tag is inherited and a composition of the groupID and artifactID -->
+	<url>https://github.com/WDAqua/Qanary-question-answering-components</url>
+	<description>QB-BirthDataWikidata is a Qanary component for creating a Wikidata SPARQL query intended to find the birth place and date of people by firstname/lastname or Wikidata resource</description>
+	<licenses>
+		<license>
+			<name>The Apache License, Version 2.0</name> <!-- Example for Apache2 Licence -->
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url> <!-- Example for Apache2 Licence -->
+		</license>
+	</licenses>
+	<developers>
+		<developer>
+			<name>Andreas Both</name>
+			<email>andreas.both@htwk-leipzig.de</email>
+			<organization>WDAqua</organization>
+			<organizationUrl>http://wdaqua.eu/</organizationUrl>
+		</developer>
+	</developers>
+
 	<properties>
 		<java.version>17</java.version>
 		<qanary.version>[3.9.2,4.0.0)</qanary.version>

--- a/qanary-component-QB-DateOfDeathDBpedia/pom.xml
+++ b/qanary-component-QB-DateOfDeathDBpedia/pom.xml
@@ -11,6 +11,26 @@
         <artifactId>qa.qanarycomponent-parent</artifactId>
         <version>[0.1.0,1.0.0)</version>
     </parent>
+
+    <!-- META INFORMATION, required due to inheritance from component-parent as parent -->
+    <!-- The name tag is inherited and a composition of the groupID and artifactID -->
+    <url>https://github.com/WDAqua/Qanary-question-answering-components</url>
+    <description>QB-DateOfDeathForRealPersons is a simple rule-based Qanary component for computing the date of death on the DBpedia knowledge base.</description>
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name> <!-- Example for Apache2 Licence -->
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url> <!-- Example for Apache2 Licence -->
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name>Andreas Both</name>
+            <email>andreas.both@htwk-leipzig.de</email>
+            <organization>WDAqua</organization>
+            <organizationUrl>http://wdaqua.eu/</organizationUrl>
+        </developer>
+    </developers>
+
     <properties>
         <java.version>17</java.version>
         <qanary.version>[3.7.6,4.0.0)</qanary.version>

--- a/qanary-component-QB-DeepPavlovWrapper/pom.xml
+++ b/qanary-component-QB-DeepPavlovWrapper/pom.xml
@@ -12,6 +12,26 @@
 		<artifactId>qa.qanarycomponent-parent</artifactId>
 		<version>[0.1.0,1.0.0)</version>
 	</parent>
+
+	<!-- META INFORMATION, required due to inheritance from component-parent as parent -->
+	<!-- The name tag is inherited and a composition of the groupID and artifactID -->
+	<url>https://github.com/WDAqua/Qanary-question-answering-components</url>
+	<description>QB-DeepPavlovWrapper is a Qanary component</description>
+	<licenses>
+		<license>
+			<name>The Apache License, Version 2.0</name> <!-- Example for Apache2 Licence -->
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url> <!-- Example for Apache2 Licence -->
+		</license>
+	</licenses>
+	<developers>
+		<developer>
+			<name>Andreas Both</name>
+			<email>andreas.both@htwk-leipzig.de</email>
+			<organization>WDAqua</organization>
+			<organizationUrl>http://wdaqua.eu/</organizationUrl>
+		</developer>
+	</developers>
+
 	<properties>
 		<java.version>17</java.version>
 		<qanary.version>[3.7.1,4.0.0)</qanary.version>

--- a/qanary-component-QB-GAnswerWrapper/pom.xml
+++ b/qanary-component-QB-GAnswerWrapper/pom.xml
@@ -12,6 +12,26 @@
       <artifactId>qa.qanarycomponent-parent</artifactId>
 	  <version>[0.1.0,1.0.0)</version>
     </parent>
+
+    <!-- META INFORMATION, required due to inheritance from component-parent as parent -->
+    <!-- The name tag is inherited and a composition of the groupID and artifactID -->
+    <url>https://github.com/WDAqua/Qanary-question-answering-components</url>
+    <description>QB-GAnswerWrapper is a Qanary component</description>
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name> <!-- Example for Apache2 Licence -->
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url> <!-- Example for Apache2 Licence -->
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name>Andreas Both</name>
+            <email>andreas.both@htwk-leipzig.de</email>
+            <organization>WDAqua</organization>
+            <organizationUrl>http://wdaqua.eu/</organizationUrl>
+        </developer>
+    </developers>
+
     <properties>
         <java.version>17</java.version>
         <docker.image.prefix>qanary</docker.image.prefix>

--- a/qanary-component-QB-PlatypusWrapper/pom.xml
+++ b/qanary-component-QB-PlatypusWrapper/pom.xml
@@ -12,6 +12,26 @@
         <artifactId>qa.qanarycomponent-parent</artifactId>
 	    <version>[0.1.0,1.0.0)</version>
     </parent>
+
+    <!-- META INFORMATION, required due to inheritance from component-parent as parent -->
+    <!-- The name tag is inherited and a composition of the groupID and artifactID -->
+    <url>https://github.com/WDAqua/Qanary-question-answering-components</url>
+    <description>QB-PlatypusWrapper is a Qanary component</description>
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name> <!-- Example for Apache2 Licence -->
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url> <!-- Example for Apache2 Licence -->
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name>Andreas Both</name>
+            <email>andreas.both@htwk-leipzig.de</email>
+            <organization>WDAqua</organization>
+            <organizationUrl>http://wdaqua.eu/</organizationUrl>
+        </developer>
+    </developers>
+
     <properties>
         <java.version>17</java.version>
         <docker.image.prefix>qanary</docker.image.prefix>

--- a/qanary-component-QB-QAnswer/pom.xml
+++ b/qanary-component-QB-QAnswer/pom.xml
@@ -11,6 +11,26 @@
         <artifactId>qa.qanarycomponent-parent</artifactId>
 	    <version>[0.1.0,1.0.0)</version>
     </parent>
+
+    <!-- META INFORMATION, required due to inheritance from component-parent as parent -->
+    <!-- The name tag is inherited and a composition of the groupID and artifactID -->
+    <url>https://github.com/WDAqua/Qanary-question-answering-components</url>
+    <description>QB-QAnswer is retrieving SPARQL query candidates for an (enriched) question from the QAnswer API </description>
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name> <!-- Example for Apache2 Licence -->
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url> <!-- Example for Apache2 Licence -->
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name>Andreas Both</name>
+            <email>andreas.both@htwk-leipzig.de</email>
+            <organization>WDAqua</organization>
+            <organizationUrl>http://wdaqua.eu/</organizationUrl>
+        </developer>
+    </developers>
+
     <properties>
         <java.version>17</java.version>
         <qanary.version>[3.7.6,4.0.0)</qanary.version>

--- a/qanary-component-QB-RuBQWrapper/pom.xml
+++ b/qanary-component-QB-RuBQWrapper/pom.xml
@@ -12,6 +12,26 @@
         <artifactId>qa.qanarycomponent-parent</artifactId>
 	    <version>[0.1.0,1.0.0)</version>
     </parent>
+
+    <!-- META INFORMATION, required due to inheritance from component-parent as parent -->
+    <!-- The name tag is inherited and a composition of the groupID and artifactID -->
+    <url>https://github.com/WDAqua/Qanary-question-answering-components</url>
+    <description>QB-RuBQWrapper is a Qanary component</description>
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name> <!-- Example for Apache2 Licence -->
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url> <!-- Example for Apache2 Licence -->
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name>Andreas Both</name>
+            <email>andreas.both@htwk-leipzig.de</email>
+            <organization>WDAqua</organization>
+            <organizationUrl>http://wdaqua.eu/</organizationUrl>
+        </developer>
+    </developers>
+
     <properties>
         <java.version>17</java.version>
         <docker.image.prefix>qanary</docker.image.prefix>

--- a/qanary-component-QB-TeBaQaWrapper/pom.xml
+++ b/qanary-component-QB-TeBaQaWrapper/pom.xml
@@ -12,6 +12,26 @@
 		<artifactId>qa.qanarycomponent-parent</artifactId>
 		<version>[0.1.0,1.0.0)</version>
 	</parent>
+
+	<!-- META INFORMATION, required due to inheritance from component-parent as parent -->
+	<!-- The name tag is inherited and a composition of the groupID and artifactID -->
+	<url>https://github.com/WDAqua/Qanary-question-answering-components</url>
+	<description>QB-TeBaQAWrapper is a Qanary component</description>
+	<licenses>
+		<license>
+			<name>The Apache License, Version 2.0</name> <!-- Example for Apache2 Licence -->
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url> <!-- Example for Apache2 Licence -->
+		</license>
+	</licenses>
+	<developers>
+		<developer>
+			<name>Andreas Both</name>
+			<email>andreas.both@htwk-leipzig.de</email>
+			<organization>WDAqua</organization>
+			<organizationUrl>http://wdaqua.eu/</organizationUrl>
+		</developer>
+	</developers>
+
 	<properties>
 		<java.version>17</java.version>
 		<docker.image.prefix>qanary</docker.image.prefix>

--- a/qanary-component-QBE-QAnswer/pom.xml
+++ b/qanary-component-QBE-QAnswer/pom.xml
@@ -11,6 +11,26 @@
 		<artifactId>qa.qanarycomponent-parent</artifactId>
 	    <version>[0.1.0,1.0.0)</version>
 	</parent>
+
+	<!-- META INFORMATION, required due to inheritance from component-parent as parent -->
+	<!-- The name tag is inherited and a composition of the groupID and artifactID -->
+	<url>https://github.com/WDAqua/Qanary-question-answering-components</url>
+	<description>QBE-QAnswer is retrieving answers for (enriched) questions from the QAnswer API</description>
+	<licenses>
+		<license>
+			<name>The Apache License, Version 2.0</name> <!-- Example for Apache2 Licence -->
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url> <!-- Example for Apache2 Licence -->
+		</license>
+	</licenses>
+	<developers>
+		<developer>
+			<name>Andreas Both</name>
+			<email>andreas.both@htwk-leipzig.de</email>
+			<organization>WDAqua</organization>
+			<organizationUrl>http://wdaqua.eu/</organizationUrl>
+		</developer>
+	</developers>
+
 	<properties>
 		<java.version>17</java.version>
 		<qanary.version>[3.7.6,4.0.0)</qanary.version>

--- a/qanary-component-QE-Wikidata/pom.xml
+++ b/qanary-component-QE-Wikidata/pom.xml
@@ -11,6 +11,26 @@
       <artifactId>qa.qanarycomponent-parent</artifactId>
       <version>[0.1.0,1.0.0)</version>
     </parent>
+
+    <!-- META INFORMATION, required due to inheritance from component-parent as parent -->
+    <!-- The name tag is inherited and a composition of the groupID and artifactID -->
+    <url>https://github.com/WDAqua/Qanary-question-answering-components</url>
+    <description>QE-Wikidata is a Qanary component</description>
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name> <!-- Example for Apache2 Licence -->
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url> <!-- Example for Apache2 Licence -->
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name>Andreas Both</name>
+            <email>andreas.both@htwk-leipzig.de</email>
+            <organization>WDAqua</organization>
+            <organizationUrl>http://wdaqua.eu/</organizationUrl>
+        </developer>
+    </developers>
+
     <properties>
         <java.version>17</java.version>
         <docker.image.prefix>qanary</docker.image.prefix>

--- a/qanary-component-TQA-ChatGPTWrapper/pom.xml
+++ b/qanary-component-TQA-ChatGPTWrapper/pom.xml
@@ -12,6 +12,26 @@
       <artifactId>qa.qanarycomponent-parent</artifactId>
       <version>[0.1.0,1.0.0)</version>
     </parent>
+
+    <!-- META INFORMATION, required due to inheritance from component-parent as parent -->
+    <!-- The name tag is inherited and a composition of the groupID and artifactID -->
+    <url>https://github.com/WDAqua/Qanary-question-answering-components</url>
+    <description>TQA-ChatGPTWrapper is a Qanary component</description>
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name> <!-- Example for Apache2 Licence -->
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url> <!-- Example for Apache2 Licence -->
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name>Andreas Both</name>
+            <email>andreas.both@htwk-leipzig.de</email>
+            <organization>WDAqua</organization>
+            <organizationUrl>http://wdaqua.eu/</organizationUrl>
+        </developer>
+    </developers>
+
     <properties>
         <java.version>17</java.version>
         <docker.image.prefix>qanary</docker.image.prefix>


### PR DESCRIPTION
Relates to https://github.com/WDAqua/Qanary/pull/276, where the component-parent artifact is adjusted to be released on Maven Central. Therefore, some information had to be added to the pom, which is inherited by the used components by default. Since this information is wrong for every component, these had to be adjusted. 