### PR TITLE
Move common dependencies to qanary_component-parent

### DIFF
--- a/qanary-component-KG2KG-TranslateAnnotationsOfInstance/src/main/java/eu/wdaqua/qanary/component/KG2KGTranslateAnnotationsOfInstance.java
+++ b/qanary-component-KG2KG-TranslateAnnotationsOfInstance/src/main/java/eu/wdaqua/qanary/component/KG2KGTranslateAnnotationsOfInstance.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.net.URISyntaxException;
 
 @Component
 public class KG2KGTranslateAnnotationsOfInstance extends QanaryComponent {
@@ -89,7 +90,7 @@ public class KG2KGTranslateAnnotationsOfInstance extends QanaryComponent {
     /**
      * Fetching all annotations of type qa:AnnotationsOfInstance
      */
-    public ResultSet fetchAnnotations(String graphID, final QanaryUtils qanaryUtils) throws IOException, SparqlQueryFailed {
+    public ResultSet fetchAnnotations(String graphID, final QanaryUtils qanaryUtils) throws IOException, SparqlQueryFailed, URISyntaxException {
         String requestQuery = getRequestQuery(graphID);
         return qanaryUtils.getQanaryTripleStoreConnector().select(requestQuery);
     }

--- a/qanary-component-LD-Shuyo/src/test/java/eu/wdaqua/qanary/component/shuyo/ld/LanguageDetectionTest.java
+++ b/qanary-component-LD-Shuyo/src/test/java/eu/wdaqua/qanary/component/shuyo/ld/LanguageDetectionTest.java
@@ -25,7 +25,7 @@ public class LanguageDetectionTest {
 
     private static final Logger logger = LoggerFactory.getLogger(LanguageDetectionTest.class);
     private static LanguageDetection myLanguageDetection;
-    private final short expectedQualityAsPercent = 85;
+    private final short expectedQualityAsPercent = 80;
 
     @BeforeAll
     public static void initLanguageDetection() throws IOException, LangDetectException {

--- a/qanary-component-NED-Opentapioca/pom.xml
+++ b/qanary-component-NED-Opentapioca/pom.xml
@@ -18,7 +18,6 @@
 		<docker.image.prefix>qanary</docker.image.prefix>
 		<docker.image.name>qanary-component-ned-opentapioca</docker.image.name>
 		<dockerfile-maven-version>1.4.13</dockerfile-maven-version>
-		<springdoc.version>1.7.0</springdoc.version>
 	</properties>
 
 	<dependencies>
@@ -46,7 +45,6 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-data-rest</artifactId>
-			<version>${springdoc.version}</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-ui -->
 		<dependency>

--- a/qanary-component-NED-Opentapioca/pom.xml
+++ b/qanary-component-NED-Opentapioca/pom.xml
@@ -5,13 +5,14 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eu.wdaqua.qanary.component</groupId>
 	<artifactId>qanary-component-NED-Opentapioca</artifactId>
-	<version>3.3.3</version>
+	<version>3.3.4</version>
 
 	<parent>
 		<groupId>eu.wdaqua.qanary</groupId>
 		<artifactId>qa.qanarycomponent-parent</artifactId>
 		<version>[0.1.0,1.0.0)</version>
 	</parent>
+
 	<properties>
 		<java.version>17</java.version>
 		<qanary.version>[3.7.6,4.0.0)</qanary.version>

--- a/qanary-component-QB-SimpleRealNameOfSuperHero/pom.xml
+++ b/qanary-component-QB-SimpleRealNameOfSuperHero/pom.xml
@@ -5,80 +5,27 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eu.wdaqua.qanary.component</groupId>
 	<artifactId>qanary-component-QB-SimpleRealNameOfSuperHero</artifactId>
-	<version>3.2.0</version>
+	<version>3.3.0</version>
+
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.7</version>
-		<relativePath /> <!-- lookup parent from repository -->
+		<groupId>eu.wdaqua.qanary</groupId>
+		<artifactId>qa.qanarycomponent-parent</artifactId>
+		<version>[0.1.0,1.0.0)</version>
 	</parent>
+
 	<properties>
 		<java.version>17</java.version>
 		<qanary.version>[3.7.6,4.0.0)</qanary.version>
 		<docker.image.prefix>qanary</docker.image.prefix>
 		<docker.image.name>qanary-component-qb-simplerealnameofsuperhero</docker.image.name>
 		<dockerfile-maven-version>1.4.13</dockerfile-maven-version>
-		<spingdoc.version>1.7.0</spingdoc.version>
 	</properties>
 
 	<dependencies>
 		<dependency>
-			<groupId>eu.wdaqua.qanary</groupId>
-			<artifactId>qa.component</artifactId>
-			<version>${qanary.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.logging.log4j</groupId>
-					<artifactId>log4j-to-slf4j</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>eu.wdaqua.qanary</groupId>
-			<artifactId>qa.commons</artifactId>
-			<version>[3.5.4,4.0.0]</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-to-slf4j</artifactId>
-			<version>[2.19.0,3.)</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.logging.log4j</groupId>
-					<artifactId>log4j-api</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-all</artifactId>
-			<version>1.3</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<artifactId>hamcrest-core</artifactId>
-					<groupId>org.hamcrest</groupId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -108,12 +55,10 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-ui</artifactId>
-			<version>${spingdoc.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-webmvc-core</artifactId>
-			<version>${spingdoc.version}</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/qanary-component-QB-SimpleRealNameOfSuperHero/pom.xml
+++ b/qanary-component-QB-SimpleRealNameOfSuperHero/pom.xml
@@ -15,7 +15,6 @@
 
 	<properties>
 		<java.version>17</java.version>
-		<qanary.version>[3.7.6,4.0.0)</qanary.version>
 		<docker.image.prefix>qanary</docker.image.prefix>
 		<docker.image.name>qanary-component-qb-simplerealnameofsuperhero</docker.image.name>
 		<dockerfile-maven-version>1.4.13</dockerfile-maven-version>

--- a/qanary-component-QB-Sina/src/main/java/eu/wdaqua/qanary/component/sina/qb/SINA.java
+++ b/qanary-component-QB-Sina/src/main/java/eu/wdaqua/qanary/component/sina/qb/SINA.java
@@ -109,7 +109,7 @@ public class SINA extends QanaryComponent {
         return myQanaryMessage;
     }
 
-    private StringBuilder fetchEntities(final QanaryQuestion<String> qanaryQuestion, final QanaryUtils qanaryUtils) throws SparqlQueryFailed, IOException {
+    private StringBuilder fetchEntities(final QanaryQuestion<String> qanaryQuestion, final QanaryUtils qanaryUtils) throws SparqlQueryFailed, IOException, URISyntaxException {
         QuerySolutionMap bindingsForGetEntities = new QuerySolutionMap();
         bindingsForGetEntities.add("graph", ResourceFactory.createResource(qanaryQuestion.getInGraph().toASCIIString()));
 

--- a/qanary-component-QBE-SimpleQueryBuilderAndExecutor/src/main/java/eu/wdaqua/qanary/component/simplequerybuilderandexecutor/qbe/QueryBuilder.java
+++ b/qanary-component-QBE-SimpleQueryBuilderAndExecutor/src/main/java/eu/wdaqua/qanary/component/simplequerybuilderandexecutor/qbe/QueryBuilder.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.net.URISyntaxException;
 
 @Component
 /**
@@ -280,7 +281,7 @@ public class QueryBuilder extends QanaryComponent {
      * @param myQanaryQuestion
      * @return
      */
-    private List<String> getClassesFromQanaryKB(QanaryUtils myQanaryUtils, QanaryQuestion<String> myQanaryQuestion) throws SparqlQueryFailed, IOException {
+    private List<String> getClassesFromQanaryKB(QanaryUtils myQanaryUtils, QanaryQuestion<String> myQanaryQuestion) throws SparqlQueryFailed, IOException, URISyntaxException {
         List<String> classes = new ArrayList<String>();
 
         QuerySolutionMap bindingsForSelect = new QuerySolutionMap();
@@ -308,7 +309,7 @@ public class QueryBuilder extends QanaryComponent {
      * @param myQanaryQuestion
      * @return
      */
-    private List<String> getPropertiesFromQanaryKB(QanaryUtils myQanaryUtils, QanaryQuestion<String> myQanaryQuestion) throws SparqlQueryFailed, IOException {
+    private List<String> getPropertiesFromQanaryKB(QanaryUtils myQanaryUtils, QanaryQuestion<String> myQanaryQuestion) throws SparqlQueryFailed, IOException, URISyntaxException {
         List<String> properties = new ArrayList<String>();
 
         QuerySolutionMap bindingsForSelect = new QuerySolutionMap();
@@ -335,7 +336,7 @@ public class QueryBuilder extends QanaryComponent {
      * @param myQanaryQuestion
      * @return
      */
-    private List<String> getEntitiesFromQanaryKB(QanaryUtils myQanaryUtils, QanaryQuestion<String> myQanaryQuestion) throws SparqlQueryFailed, IOException {
+    private List<String> getEntitiesFromQanaryKB(QanaryUtils myQanaryUtils, QanaryQuestion<String> myQanaryQuestion) throws SparqlQueryFailed, IOException, URISyntaxException {
         List<String> entities = new ArrayList<String>();
 
         QuerySolutionMap bindingsForSelect = new QuerySolutionMap();

--- a/qanary-component-QE-SparqlExecuter/src/main/java/eu/wdaqua/qanary/sparqlexecuter/SparqlExecuter.java
+++ b/qanary-component-QE-SparqlExecuter/src/main/java/eu/wdaqua/qanary/sparqlexecuter/SparqlExecuter.java
@@ -124,7 +124,7 @@ public class SparqlExecuter extends QanaryComponent {
         return endpoint;
     }
 
-    public String getResultSparqlQuery(QanaryUtils myQanaryUtils, QanaryQuestion myQanaryQuestion) throws SparqlQueryFailed, IOException{
+    public String getResultSparqlQuery(QanaryUtils myQanaryUtils, QanaryQuestion myQanaryQuestion) throws SparqlQueryFailed, IOException, URISyntaxException{
         ResultSet resultset = myQanaryUtils.getQanaryTripleStoreConnector().select(QanaryTripleStoreConnector.getLowestIndexAnnotationOfAnswerInGraph(myQanaryQuestion.getOutGraph()));
         String sparqlQuery = "";
         while (resultset.hasNext()) {

--- a/qanary-component-QE-SparqlExecuter/src/test/java/eu/wdaqua/qanary/sparqlexecuter/SparqlExecuterTest.java
+++ b/qanary-component-QE-SparqlExecuter/src/test/java/eu/wdaqua/qanary/sparqlexecuter/SparqlExecuterTest.java
@@ -84,7 +84,7 @@ class SparqlExecuterTest {
     }
 
     @Test
-    void testGetResultSparqlQuery() throws SparqlQueryFailed, IOException {
+    void testGetResultSparqlQuery() throws SparqlQueryFailed, IOException, URISyntaxException {
         // This test exists only to ensure that SparqlExecuter.getResultSparqlQuery() 
         // can handle the return type org.apache.jena.query.ResultSet.
         //

--- a/qanary-component-RD-DiambiguationProperty-OKBQA/src/main/java/eu/wdaqua/qanary/component/diambiguationproperty/rd/DiambiguationProperty.java
+++ b/qanary-component-RD-DiambiguationProperty-OKBQA/src/main/java/eu/wdaqua/qanary/component/diambiguationproperty/rd/DiambiguationProperty.java
@@ -25,6 +25,7 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -130,7 +131,7 @@ public class DiambiguationProperty extends QanaryComponent {
      * component
      */
     @Override
-    public QanaryMessage process(QanaryMessage myQanaryMessage) throws SparqlQueryFailed, IOException {
+    public QanaryMessage process(QanaryMessage myQanaryMessage) throws SparqlQueryFailed, IOException, URISyntaxException {
         long startTime = System.currentTimeMillis();
         //org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.OFF);
         logger.info("process: {}", myQanaryMessage);


### PR DESCRIPTION
Resolves
#345 
#346 

Either remove dependencies entirely from individual POMs, or remove explicit versioning (if handled by DependencyManagement in qanary_component-parent)