### PR TITLE
NER-Stanford: bump stanford-corenlp 4.5.9 -> 4.5.10

### DIFF
--- a/qanary-component-NER-Stanford/pom.xml
+++ b/qanary-component-NER-Stanford/pom.xml
@@ -40,14 +40,14 @@
         <dependency>
             <groupId>edu.stanford.nlp</groupId>
             <artifactId>stanford-corenlp</artifactId>
-            <version>4.5.9</version>
+            <version>4.5.10</version>
         </dependency>
         <!-- the NER tagger models ship in the 'models' classifier jar; required at
              runtime and by StanfordNERComponentTest (the migration dropped it). -->
         <dependency>
             <groupId>edu.stanford.nlp</groupId>
             <artifactId>stanford-corenlp</artifactId>
-            <version>4.5.9</version>
+            <version>4.5.10</version>
             <classifier>models</classifier>
         </dependency>
         <dependency>


### PR DESCRIPTION
Applies Snyk #385 (which conflicted after #388 rewrote this pom). Bumps both the main and `models` classifier stanford-corenlp deps to 4.5.10. Supersedes #385.

🤖 Generated with [Claude Code](https://claude.com/claude-code)